### PR TITLE
small Github actions improvements

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,7 +2,9 @@ name: Build
 on:
   push:
     branches:
-    - "main"
+      - "main"
+    tags:
+      - "*"
   pull_request: {}
 jobs:
   build:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,9 +17,9 @@ jobs:
         - 1.17
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Build
@@ -27,7 +27,7 @@ jobs:
       - name: vet
         run: go vet ./...
       - name: Upload vfkit artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: vfkit Universal Binary (${{ matrix.os }})
           path: "./out/vfkit"

--- a/cmd/vfkit/root.go
+++ b/cmd/vfkit/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const vfkitVersion = "0.0.2"
+const vfkitVersion = "0.0.4"
 
 var opts = &cmdlineOptions{}
 


### PR DESCRIPTION
This upgrades to the latest version of the checkout/upload-artifact/.. actions to silence warnings.
This also triggers vfkit builds when a tag is pushed.