### PR TITLE
Add --log-level option

### DIFF
--- a/cmd/vfkit/root.go
+++ b/cmd/vfkit/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/crc-org/vfkit/pkg/cmdline"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,13 @@ var rootCmd = &cobra.Command{
 	Long: `A hypervisor written in Go using Apple's virtualization framework to run linux virtual machines.
                 Complete documentation is available at https://github.com/crc-org/vfkit`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(opts.LogLevel) > 0 {
+			ll, err := getLogLevel()
+			if err != nil {
+				return err
+			}
+			logrus.SetLevel(ll)
+		}
 		vmConfig, err := newVMConfiguration(opts)
 		if err != nil {
 			return err
@@ -34,6 +42,18 @@ func init() {
 	versionTmpl := `{{with .Name}}{{printf "%s " .}}{{end}}{{printf "version: %s" .Version}}
 `
 	rootCmd.SetVersionTemplate(versionTmpl)
+}
+
+func getLogLevel() (logrus.Level, error) {
+	switch opts.LogLevel {
+	case "error":
+		return logrus.ErrorLevel, nil
+	case "debug":
+		return logrus.DebugLevel, nil
+	case "info":
+		return logrus.InfoLevel, nil
+	}
+	return 0, fmt.Errorf("unknown log level: %s", opts.LogLevel)
 }
 
 func Execute() {

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -8,6 +8,11 @@ Specifying VM bootloader configuration is mandatory.
 Device configuration is optional, but most VM will need a disk image and a network interface to be configured.
 
 ## Generic Options
+
+- `--log-level`
+
+Set the log-level for VFKit.  Supported values are `debug`, `info`, and `error`.
+
 ### Virtual Machine Resources
 
 These options specify the amount of RAM and the number of CPUs which will be available to the virtual machine.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/sys v0.3.0
 	inet.af/tcpproxy v0.0.0-20220326234310-be3ee21c9fa0
 )
 
@@ -20,7 +21,6 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
-	golang.org/x/sys v0.3.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -15,6 +15,8 @@ type Options struct {
 	TimeSync string
 
 	Devices []string
+
+	LogLevel string
 }
 
 func AddFlags(cmd *cobra.Command, opts *Options) {
@@ -36,4 +38,6 @@ func AddFlags(cmd *cobra.Command, opts *Options) {
 	cmd.Flags().StringVarP(&opts.TimeSync, "timesync", "t", "", "sync guest time when host wakes up from sleep")
 
 	cmd.Flags().StringArrayVarP(&opts.Devices, "device", "d", []string{}, "devices")
+
+	cmd.Flags().StringVar(&opts.LogLevel, "log-level", "", "set log level")
 }


### PR DESCRIPTION
added a log-level option for users to be able to set the various golang logging levels. at present, only `error`, `info`, and `debug` are accepted.