### PR TITLE
Change State-related struct and field name

### DIFF
--- a/pkg/rest/config.go
+++ b/pkg/rest/config.go
@@ -3,7 +3,7 @@ package rest
 type ServiceScheme int
 
 const (
-	Tcp ServiceScheme = iota
+	TCP ServiceScheme = iota
 	Unix
 	None
 )

--- a/pkg/rest/define/config.go
+++ b/pkg/rest/define/config.go
@@ -5,23 +5,15 @@ package define
 type InspectResponse struct {
 	CPUs   uint   `json:"cpus"`
 	Memory uint64 `json:"memory"`
-	//Devices []config.VirtioDevice `json:"devices"`
+	// Devices []config.VirtioDevice `json:"devices"`
 }
 
-// StateResponse is for responding to a request for virtual
-// machine state
-type StateResponse struct {
+// VMState can be used to describe the current state of a VM
+// as well as used to request a state change
+type VMState struct {
 	State string `json:"state"`
 }
 
-// StateChangeRequest is used by the restful service consumer
-// to ask for a virtual machine state change
-type StateChangeRequest struct {
-	NewState StateChange `json:"new_state"`
-}
-
-// StateChange is a string strong typing of values for changing
-// the state of a virtual machine
 type StateChange string
 
 const (

--- a/pkg/rest/rest_test.go
+++ b/pkg/rest/rest_test.go
@@ -2,9 +2,10 @@ package rest
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseRestfulURI(t *testing.T) {
@@ -130,7 +131,7 @@ func TestToRestScheme(t *testing.T) {
 			args: args{
 				s: "tcp",
 			},
-			want:    Tcp,
+			want:    TCP,
 			wantErr: assert.NoError,
 		},
 		{

--- a/pkg/rest/state_change.go
+++ b/pkg/rest/state_change.go
@@ -1,19 +1,32 @@
 package rest
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/Code-Hex/vz/v3"
 	"github.com/crc-org/vfkit/pkg/rest/define"
 	"github.com/sirupsen/logrus"
 )
 
-// ErrNotImplemented Temporary Error Message
-var ErrNotImplemented = errors.New("function not implemented yet")
-
 // ChangeState execute a state change (i.e. running to stopped)
 func (vm *VzVirtualMachine) ChangeState(newState define.StateChange) error {
-	return ErrNotImplemented
+	var (
+		response error
+	)
+	switch newState {
+	case define.Pause:
+		response = vm.Pause()
+	case define.Resume:
+		response = vm.Resume()
+	case define.Stop:
+		response = vm.Stop()
+	case define.HardStop:
+		response = vm.HardStop()
+	default:
+		logrus.Error(response)
+		return fmt.Errorf("invalid new VMState: %s", newState)
+	}
+	return response
 }
 
 // GetState returns state of the VM

--- a/pkg/rest/vm_config.go
+++ b/pkg/rest/vm_config.go
@@ -6,7 +6,6 @@ import (
 
 type VzVirtualMachine struct {
 	VzVM   *vz.VirtualMachine
-	state  vz.VirtualMachineState
 	config *vz.VirtualMachineConfiguration
 }
 


### PR DESCRIPTION
It is more idiomatic (restful) to use the same structure GET and POST endpoints that are similar.

Removing the StateChange struct and replace it renamed struct called VMState (was StateResponse).

go linting cleanups were also done, which required some slight refactoring.