### PR TITLE
doc: Add missing `

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -148,7 +148,7 @@ The `--device virtio-net` option adds a network interface to the virtual machine
 - `mac`: optional argument to specify the MAC address of the VM. If it's omitted, a random MAC address will be used.
 - `fd`: file descriptor to attach to the guest network interface. The file descriptor must be a connected datagram socket. See [VZFileHandleNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vzfilehandlenetworkdeviceattachment?language=objc) for more details.
 - `nat`: guest network traffic will be NAT'ed through the host. This is the default. See [VZNATNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vznatnetworkdeviceattachment?language=objc) for more details.
-- `unixSocketPath: path to a unix socket to attach to the guest network interface. See See [VZFileHandleNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vzfilehandlenetworkdeviceattachment?language=objc) for more details.
+- `unixSocketPath`: path to a unix socket to attach to the guest network interface. See See [VZFileHandleNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vzfilehandlenetworkdeviceattachment?language=objc) for more details.
 
 `fd`, `nat`, `unixSocketPath` are mutually exclusive.
 


### PR DESCRIPTION
This breaks `unixSocketPath` formatting