### PR TITLE
virtiofs: Allow to add multiple virtio-fs devices

### DIFF
--- a/pkg/vf/vm.go
+++ b/pkg/vf/vm.go
@@ -9,7 +9,8 @@ import (
 
 type vzVirtualMachineConfiguration struct {
 	*vz.VirtualMachineConfiguration
-	storageDeviceConfiguration []vz.StorageDeviceConfiguration
+	storageDeviceConfiguration          []vz.StorageDeviceConfiguration
+	directorySharingDeviceConfiguration []vz.DirectorySharingDeviceConfiguration
 }
 
 func newVzVirtualMachineConfiguration(vm *config.VirtualMachine) (*vzVirtualMachineConfiguration, error) {
@@ -40,6 +41,7 @@ func ToVzVirtualMachineConfig(vm *config.VirtualMachine) (*vz.VirtualMachineConf
 		}
 	}
 	vzVMConfig.SetStorageDevicesVirtualMachineConfiguration(vzVMConfig.storageDeviceConfiguration)
+	vzVMConfig.SetDirectorySharingDevicesVirtualMachineConfiguration(vzVMConfig.directorySharingDeviceConfiguration)
 
 	if vm.Timesync != nil && vm.Timesync.VsockPort != 0 {
 		// automatically add the vsock device we'll need for communication over VsockPort


### PR DESCRIPTION
This does the same refactoring as for VirtioBlk in commit 36574dd
and 0a83544

This does not try to detect duplicate mount tags, or to allow to use
multiple directories with the same virtio-fs device.

This partially fixes https://github.com/crc-org/vfkit/issues/41