### PR TITLE
Add support for a GUI, virtio-input and virtio-gpu devices

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -214,6 +214,33 @@ The share can be mounted in the guest with `mount -t virtiofs vfkitTag /mnt`, wi
 #### Example
 `--device virtio-fs,sharedDir=/Users/virtuser/vfkit/,mountTag=vfkit-share`
 
+### GPU
+
+#### Description
+
+The `--device virtio-gpu` option allows the user to add graphical devices to the virtual machine.
+
+#### Arguments
+- `height`: the vertical resolution of the graphical device's resolution. Defaults to 800
+- `width`: the horizontal resolution of the graphical device's resolution. Defaults to 600
+
+#### Example
+`--device virtio-gpu,height=1920,width=1080`
+
+### Input
+
+#### Description
+
+The `--device virtio-input` option allows the user to add an input device to the virtual machine. This currently supports `pointing` and `keyboard` devices.
+
+#### Arguments
+
+None
+
+#### Example
+
+`--device virtio-input,pointing`
+
 
 ## Restful Service
 
@@ -242,3 +269,20 @@ Get description of the virtual machine
 
 GET `/vm/inspect`
 Response: { "cpus": uint, "memory": uint64, "devices": []config.VirtIODevice }
+
+## Enabling a Graphical User Interface
+
+### Add a virtio-gpu device
+
+In order to successfully start a graphical application window, a virtio-gpu device must be added to the virtual machine.
+
+### Pass the `--gui` flag
+
+In order to tell vfkit that you want to start a graphical application window, you need to pass the `--gui` flag in your command.
+
+### Usage
+
+Proper use of this flag may look similar to the following section of a command: 
+```bash
+--device virtio-input,keyboard --device virtio-input,pointing --device virtio-gpu,height=1920,width=1000 --gui
+```

--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -21,6 +21,8 @@ type Options struct {
 	RestfulURI string
 
 	LogLevel string
+
+	UseGUI bool
 }
 
 const DefaultRestfulURI = "none://"
@@ -31,6 +33,7 @@ func AddFlags(cmd *cobra.Command, opts *Options) {
 	cmd.Flags().StringVarP(&opts.InitrdPath, "initrd", "i", "", "path to the virtual machine initrd")
 
 	cmd.Flags().VarP(&opts.Bootloader, "bootloader", "b", "bootloader configuration")
+	cmd.Flags().BoolVar(&opts.UseGUI, "gui", false, "display the contents of the virtual machine onto a graphical user interface")
 
 	cmd.MarkFlagsMutuallyExclusive("kernel", "bootloader")
 	cmd.MarkFlagsMutuallyExclusive("initrd", "bootloader")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,17 @@ func (vm *VirtualMachine) AddDevicesFromCmdLine(cmdlineOpts []string) error {
 	return nil
 }
 
+func (vm *VirtualMachine) VirtioGPUDevices() []*VirtioGPU {
+	gpuDevs := []*VirtioGPU{}
+	for _, dev := range vm.Devices {
+		if gpuDev, isVirtioGPU := dev.(*VirtioGPU); isVirtioGPU {
+			gpuDevs = append(gpuDevs, gpuDev)
+		}
+	}
+
+	return gpuDevs
+}
+
 func (vm *VirtualMachine) VirtioVsockDevices() []*VirtioVsock {
 	vsockDevs := []*VirtioVsock{}
 	for _, dev := range vm.Devices {

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -140,6 +140,43 @@ var virtioDevTests = map[string]virtioDevTest{
 		},
 		expectedCmdLine: []string{"--device", "usb-mass-storage,path=/foo/bar"},
 	},
+	"NewVirtioInputWithPointingDevice": {
+		newDev: func() (VirtioDevice, error) { return VirtioInputNew("pointing") },
+		expectedDev: &VirtioInput{
+			InputType: "pointing",
+		},
+		expectedCmdLine: []string{"--device", "virtio-input,pointing"},
+	},
+	"NewVirtioInputWithKeyboardDevice": {
+		newDev: func() (VirtioDevice, error) { return VirtioInputNew("keyboard") },
+		expectedDev: &VirtioInput{
+			InputType: "keyboard",
+		},
+		expectedCmdLine: []string{"--device", "virtio-input,keyboard"},
+	},
+	"NewVirtioGPUDevice": {
+		newDev: VirtioGPUNew,
+		expectedDev: &VirtioGPU{
+			false,
+			VirtioGPUResolution{800, 600},
+		},
+		expectedCmdLine: []string{"--device", "virtio-gpu,height=800,width=600"},
+	},
+	"NewVirtioGPUDeviceWithDimensions": {
+		newDev: func() (VirtioDevice, error) {
+			dev, err := VirtioGPUNew()
+			if err != nil {
+				return nil, err
+			}
+			dev.(*VirtioGPU).VirtioGPUResolution = VirtioGPUResolution{1920, 1080}
+			return dev, nil
+		},
+		expectedDev: &VirtioGPU{
+			false,
+			VirtioGPUResolution{1920, 1080},
+		},
+		expectedCmdLine: []string{"--device", "virtio-gpu,height=1920,width=1080"},
+	},
 }
 
 func testVirtioDev(t *testing.T, test *virtioDevTest) {


### PR DESCRIPTION
Adds command line support for the user to add virtio-gpu and virtio-input devices which also ties into having a good experience with the newly added gui compatability.

Adds command line support for the user to start a graphical application window when their virtual machine starts through the `--gui` flag (assuming the user added a virtio-gpu device as well).

Adds some mutual exclusion during creation of the virtual machine configuration. Without calling `runtime.LockOSThread()`, starting the virtual machine subsequently starting a graphic application window would result in a SIGILL error. Alongside calling `runtime.LockOSThread()`, parallelized the running of the graphic application window and checking the status of the virtual machine. Otherwise, the two wouldn't be able to run simultaneously.

These new features can be testing using a command similar to this:

```bash
$ ./out/vfkit --cpus 2 --memory 2048 \
--bootloader efi,variable-store=/Users/jakecorrenti/efi-variable-store,create \
--device virtio-serial,stdio \
--device virtio-fs,sharedDir=/Users/jakecorrenti,mountTag=dir0 \
--device virtio-blk,path=/Users/jakecorrenti/Downloads/Fedora-Server-dvd-x86_64-38-1.6.iso \
--device virtio-net,nat,mac=72:20:43:d4:38:62 --device virtio-input,keyboard --device virtio-input,pointing --device virtio-gpu --gui
```