### PR TITLE
No CGO for rest consumers/clients

### DIFF
--- a/pkg/rest/config.go
+++ b/pkg/rest/config.go
@@ -1,10 +1,1 @@
 package rest
-
-type ServiceScheme int
-
-const (
-	TCP ServiceScheme = iota
-	Unix
-	None
-	HTTP
-)

--- a/pkg/rest/define/config.go
+++ b/pkg/rest/define/config.go
@@ -1,5 +1,12 @@
 package define
 
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
 // InspectResponse is used when responding to a request for
 // information about the virtual machine
 type InspectResponse struct {
@@ -21,4 +28,91 @@ const (
 	Pause    StateChange = "Pause"
 	Stop     StateChange = "Stop"
 	HardStop StateChange = "HardStop"
+)
+
+type Endpoint struct {
+	Host   string
+	Path   string
+	Scheme ServiceScheme
+}
+
+func NewEndpoint(input string) (*Endpoint, error) {
+	uri, err := parseRestfulURI(input)
+	if err != nil {
+		return nil, err
+	}
+	scheme, err := toRestScheme(uri.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	return &Endpoint{
+		Host:   uri.Host,
+		Path:   uri.Path,
+		Scheme: scheme,
+	}, nil
+}
+
+func (ep *Endpoint) ToCmdLine() ([]string, error) {
+	args := []string{"--restful-uri"}
+	switch ep.Scheme {
+	case Unix:
+		args = append(args, fmt.Sprintf("unix://%s", ep.Path))
+	case TCP:
+		args = append(args, fmt.Sprintf("tcp://%s%s", ep.Host, ep.Path))
+	case None:
+		return []string{}, nil
+	default:
+		return []string{}, errors.New("invalid endpoint scheme")
+	}
+	return args, nil
+}
+
+// parseRestfulURI validates the input URI and returns an URL object
+func parseRestfulURI(inputURI string) (*url.URL, error) {
+	restURI, err := url.ParseRequestURI(inputURI)
+	if err != nil {
+		return nil, err
+	}
+	scheme, err := toRestScheme(restURI.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	if scheme == TCP && len(restURI.Host) < 1 {
+		return nil, errors.New("invalid TCP uri: missing host")
+	}
+	if scheme == TCP && len(restURI.Path) > 0 {
+		return nil, errors.New("invalid TCP uri: path is forbidden")
+	}
+	if scheme == TCP && restURI.Port() == "" {
+		return nil, errors.New("invalid TCP uri: missing port")
+	}
+	if scheme == Unix && len(restURI.Path) < 1 {
+		return nil, errors.New("invalid unix uri: missing path")
+	}
+	if scheme == Unix && len(restURI.Host) > 0 {
+		return nil, errors.New("invalid unix uri: host is forbidden")
+	}
+	return restURI, err
+}
+
+// toRestScheme converts a string to a ServiceScheme
+func toRestScheme(s string) (ServiceScheme, error) {
+	switch strings.ToUpper(s) {
+	case "NONE":
+		return None, nil
+	case "UNIX":
+		return Unix, nil
+	case "TCP", "HTTP":
+		return TCP, nil
+	}
+	return None, fmt.Errorf("invalid scheme %s", s)
+}
+
+type ServiceScheme int
+
+const (
+	TCP ServiceScheme = iota
+	Unix
+	None
+	HTTP
 )

--- a/pkg/rest/define/rest_test.go
+++ b/pkg/rest/define/rest_test.go
@@ -1,4 +1,4 @@
-package rest
+package define
 
 import (
 	"fmt"
@@ -158,67 +158,6 @@ func TestToRestScheme(t *testing.T) {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "toRestScheme(%v)", tt.args.s)
-		})
-	}
-}
-
-func Test_validateRestfulURI(t *testing.T) {
-	type args struct {
-		inputURI string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "valid tcp",
-			args: args{
-				inputURI: "tcp://localhost:8080",
-			},
-			wantErr: false,
-		},
-		{
-			name: "invalid tcp - no host",
-			args: args{
-				inputURI: "tcp://",
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid scheme",
-			args: args{
-				inputURI: "http://localhost",
-			},
-			wantErr: true,
-		},
-		{
-			name: "valid uds",
-			args: args{
-				inputURI: "unix:///my/socket/goes/here/vfkit.sock",
-			},
-			wantErr: false,
-		},
-		{
-			name: "invalid uds - no path",
-			args: args{
-				inputURI: "unix://",
-			},
-			wantErr: true,
-		},
-		{
-			name: "none",
-			args: args{
-				inputURI: "none://",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := validateRestfulURI(tt.args.inputURI); (err != nil) != tt.wantErr {
-				t.Errorf("validateRestfulURI() error = %v, wantErr %v", err, tt.wantErr)
-			}
 		})
 	}
 }


### PR DESCRIPTION
Refactored portions of the rest code to not require CGO for rest consumers.  Most of the refactored code was moved into pkg/rest/define to isolate it.

Also pruned an unused function and related unit test.