### PR TITLE
feat(rest): add can* params in `GET /vm/state`

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -351,17 +351,19 @@ None
 Used to obtain the state of the virtual machine that is being run by VFKit.
 
 GET `/vm/state`
-Response: {"state": "string"}
+Response: { "state": string, "canStart": bool, "canPause": bool, "canResume": bool, "canStop": bool, "canHardStop": bool }
+
+> `canHardStop` is only supported on macOS 12 and newer, false will always be returned on older versions.
 
 ### Change VM State
 
 Change the state of the virtual machine. Valid states are:
-* Hardstop
+* HardStop
 * Pause
 * Resume
 * Stop
 
-POST `/vm/state` {"new_state": "new value"}
+POST `/vm/state` { "state": "new value"}
 
 Response: http 200
 

--- a/pkg/rest/vf/state_change.go
+++ b/pkg/rest/vf/state_change.go
@@ -53,3 +53,23 @@ func (vm *VzVirtualMachine) HardStop() error {
 	logrus.Debug("force stopping machine")
 	return vm.VzVM.Stop()
 }
+
+func (vm *VzVirtualMachine) CanStart() bool {
+	return vm.VzVM.CanStart()
+}
+
+func (vm *VzVirtualMachine) CanPause() bool {
+	return vm.VzVM.CanPause()
+}
+
+func (vm *VzVirtualMachine) CanResume() bool {
+	return vm.VzVM.CanResume()
+}
+
+func (vm *VzVirtualMachine) CanStop() bool {
+	return vm.VzVM.CanRequestStop()
+}
+
+func (vm *VzVirtualMachine) CanHardStop() bool {
+	return vm.VzVM.CanStop()
+}

--- a/pkg/rest/vf/vm_config.go
+++ b/pkg/rest/vf/vm_config.go
@@ -33,7 +33,14 @@ func (vm *VzVirtualMachine) Inspect(c *gin.Context) {
 // getVMState retrieves the current vm state
 func (vm *VzVirtualMachine) GetVMState(c *gin.Context) {
 	current := vm.GetState()
-	c.JSON(http.StatusOK, gin.H{"state": current.String()})
+	c.JSON(http.StatusOK, gin.H{
+		"state":       current.String(),
+		"canStart":    vm.CanStart(),
+		"canPause":    vm.CanPause(),
+		"canResume":   vm.CanResume(),
+		"canStop":     vm.CanStop(),
+		"canHardStop": vm.CanHardStop(),
+	})
 }
 
 // setVMState requests a state change on a virtual machine.  At this time only


### PR DESCRIPTION
In the previous API, there was no way to detect before changing the status, which would make it difficult for developers to handle the following situations:

1. When the virtual machine status is Stop, calling Pause may fail.
2. When the virtual machine status is Pause, setting the status to Pause again may fail.

In the previous solution, developers needed to first get the current status of the virtual machine and then decide whether to proceed to the next step. However, the current virtual machine status is very diverse (see: https://github.com/Code-Hex/vz/blob/bd29a7ea3d39465c4224bfb01e990e8c220a8449/virtualization.go#L23), which would require developers to handle various cases perfectly. This PR solves this problem.