### PR TITLE
Generate vfkit version from git tag

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/pkg/cmdline/version.go export-subst

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -21,6 +21,15 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: >-
+          WORKAROUND: Fetch tags that points to the revisions
+          checked-out(actions/checkout#1467)
+        run: |-
+          git fetch --tags --force
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all build clean test
 
+GIT_VERSION ?= $(shell git describe --always --dirty)
 CGO_CFLAGS=-mmacosx-version-min=11.0
+VERSION_LDFLAGS=-X github.com/crc-org/vfkit/pkg/cmdline.gitVersion=$(GIT_VERSION)
 
 all: build
 
@@ -17,7 +19,7 @@ clean:
 
 out/vfkit-amd64 out/vfkit-arm64: out/vfkit-%: force-build
 	@mkdir -p $(@D)
-	CGO_ENABLED=1 CGO_CFLAGS=$(CGO_CFLAGS) GOOS=darwin GOARCH=$* go build -o $@ ./cmd/vfkit
+	CGO_ENABLED=1 CGO_CFLAGS=$(CGO_CFLAGS) GOOS=darwin GOARCH=$* go build -ldflags "$(VERSION_LDFLAGS)" -o $@ ./cmd/vfkit
 	codesign --entitlements vf.entitlements -s - $@
 
 out/vfkit: out/vfkit-amd64 out/vfkit-arm64

--- a/cmd/vfkit/root.go
+++ b/cmd/vfkit/root.go
@@ -9,8 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const vfkitVersion = "0.5.1"
-
 var opts = &cmdline.Options{}
 
 var rootCmd = &cobra.Command{
@@ -32,7 +30,7 @@ var rootCmd = &cobra.Command{
 		}
 		return runVFKit(vmConfig, opts)
 	},
-	Version: vfkitVersion,
+	Version: cmdline.Version(),
 }
 
 func init() {

--- a/pkg/cmdline/version.go
+++ b/pkg/cmdline/version.go
@@ -1,8 +1,30 @@
 package cmdline
 
+import (
+	"runtime/debug"
+)
+
 // set using the '-X github.com/crc-org/vfkit/pkg/cmdline.gitVersion' linker flag
 var gitVersion = "unknown"
 
 func Version() string {
-	return gitVersion
+	switch {
+	// This will be set when building from git using make
+	case gitVersion != "":
+		return gitVersion
+	// moduleVersionFromBuildInfo() will be set when using `go install`
+	default:
+		return moduleVersionFromBuildInfo()
+	}
+}
+
+func moduleVersionFromBuildInfo() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	if info.Main.Version == "(devel)" {
+		return ""
+	}
+	return info.Main.Version
 }

--- a/pkg/cmdline/version.go
+++ b/pkg/cmdline/version.go
@@ -2,13 +2,23 @@ package cmdline
 
 import (
 	"runtime/debug"
+	"strings"
 )
 
-// set using the '-X github.com/crc-org/vfkit/pkg/cmdline.gitVersion' linker flag
-var gitVersion = "unknown"
+var (
+	// set using the '-X github.com/crc-org/vfkit/pkg/cmdline.gitVersion' linker flag
+	gitVersion = "unknown"
+
+	// set through .gitattributes when `git archive` is used
+	// see https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/
+	gitArchiveVersion = "$Format:%(describe)$"
+)
 
 func Version() string {
 	switch {
+	// This will be substituted when building from a GitHub tarball
+	case !strings.HasPrefix(gitArchiveVersion, "$Format:"):
+		return gitArchiveVersion
 	// This will be set when building from git using make
 	case gitVersion != "":
 		return gitVersion

--- a/pkg/cmdline/version.go
+++ b/pkg/cmdline/version.go
@@ -1,0 +1,8 @@
+package cmdline
+
+// set using the '-X github.com/crc-org/vfkit/pkg/cmdline.gitVersion' linker flag
+var gitVersion = "unknown"
+
+func Version() string {
+	return gitVersion
+}


### PR DESCRIPTION
Currently the vfkit version must be manually set
before making a release, which is error-prone (this was the reason for the
0.1.1 release).
This PR generates it from git tags instead using git describe.
It also uses some git-archive magic to set the proper version
when a tarball is used for building vfkit.