### PR TITLE
refactor(rest): improve inspect api

### DIFF
--- a/cmd/vfkit/main.go
+++ b/cmd/vfkit/main.go
@@ -131,7 +131,7 @@ func runVFKit(vmConfig *config.VirtualMachine, opts *cmdline.Options) error {
 
 	// Do not enable the rests server if user sets scheme to None
 	if opts.RestfulURI != cmdline.DefaultRestfulURI {
-		restVM := restvf.NewVzVirtualMachine(vm, vzVMConfig)
+		restVM := restvf.NewVzVirtualMachine(vm, vzVMConfig, vmConfig)
 		srv, err := rest.NewServer(restVM, restVM, opts.RestfulURI)
 		if err != nil {
 			return err

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -56,7 +56,7 @@ var jsonTests = map[string]jsonTest{
 			require.NoError(t, err)
 			return vm
 		},
-		expectedJSON: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"virtioblk","DevName":"virtio-blk","ImagePath":"/virtioblk1","ReadOnly":false,"DeviceIdentifier":""},{"kind":"virtioblk","DevName":"virtio-blk","ImagePath":"/virtioblk2","ReadOnly":false,"DeviceIdentifier":"virtio-blk2"}]}`,
+		expectedJSON: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk1","readOnly":false,"deviceIdentifier":""},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk2","readOnly":false,"deviceIdentifier":"virtio-blk2"}]}`,
 	},
 	"TestAllVirtioDevices": {
 		newVM: func(t *testing.T) *VirtualMachine {
@@ -110,7 +110,7 @@ var jsonTests = map[string]jsonTest{
 
 			return vm
 		},
-		expectedJSON: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"virtioserial","LogFile":"/virtioserial","UsesStdio":false},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","Nat":true,"MacAddress":"ABEiM0RV","Socket":null,"UnixSocketPath":""},{"kind":"virtiorng"},{"kind":"virtioblk","DevName":"virtio-blk","ImagePath":"/virtioblk","ReadOnly":false,"DeviceIdentifier":""},{"kind":"virtiosock","Port":1234,"SocketURL":"/virtiovsock","Listen":false},{"kind":"virtiofs","MountTag":"tag","SharedDir":"/virtiofs"},{"kind":"usbmassstorage","DevName":"usb-mass-storage","ImagePath":"/usbmassstorage","ReadOnly":false},{"kind":"rosetta","MountTag":"vz-rosetta","InstallRosetta":false}]}`,
+		expectedJSON: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial","usesStdio":false},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"ABEiM0RV","socket":null,"unixSocketPath":""},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk","readOnly":false,"deviceIdentifier":""},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock","listen":false},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":false},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false}]}`,
 	},
 }
 
@@ -129,13 +129,13 @@ var invalidJSONTests = map[string]invalidJSONTest{
 		json: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"}}`,
 	},
 	"TestEmptyDeviceKind": {
-		json: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"","DevName":"virtio-blk","ImagePath":"/virtioblk1","ReadOnly":false,"DeviceIdentifier":""}]}`,
+		json: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"","devName":"virtio-blk","imagePath":"/virtioblk1","readOnly":false,"deviceIdentifier":""}]}`,
 	},
 	"TestInvalidDeviceKind": {
-		json: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"invalid","DevName":"virtio-blk","ImagePath":"/virtioblk1","ReadOnly":false,"DeviceIdentifier":""}]}`,
+		json: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"kind":"invalid","devName":"virtio-blk","imagePath":"/virtioblk1","readOnly":false,"deviceIdentifier":""}]}`,
 	},
 	"TestMissingDeviceKind": {
-		json: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"DevName":"virtio-blk","ImagePath":"/virtioblk1","ReadOnly":false,"DeviceIdentifier":""}]}`,
+		json: `{"vcpus":3,"memoryBytes":4000000000,"bootloader":{"kind":"linuxBootloader","VmlinuzPath":"/vmlinuz","KernelCmdLine":"/initrd","InitrdPath":"console=hvc0"},"devices":[{"devName":"virtio-blk","imagePath":"/virtioblk1","readOnly":false,"deviceIdentifier":""}]}`,
 	},
 }
 

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -47,34 +47,34 @@ type VirtioGPU struct {
 type VirtioVsock struct {
 	// Port is the virtio-vsock port used for this device, see `man vsock` for more
 	// details.
-	Port uint
+	Port uint `json:"port"`
 	// SocketURL is the path to a unix socket on the host to use for the virtio-vsock communication with the guest.
-	SocketURL string
+	SocketURL string `json:"socketURL"`
 	// If true, vsock connections will have to be done from guest to host. If false, vsock connections will only be possible
 	// from host to guest
-	Listen bool
+	Listen bool `json:"listen"`
 }
 
 // VirtioBlk configures a disk device.
 type VirtioBlk struct {
 	StorageConfig
-	DeviceIdentifier string
+	DeviceIdentifier string `json:"deviceIdentifier"`
 }
 
 type DirectorySharingConfig struct {
-	MountTag string
+	MountTag string `json:"mountTag"`
 }
 
 // VirtioFs configures directory sharing between the guest and the host.
 type VirtioFs struct {
 	DirectorySharingConfig
-	SharedDir string
+	SharedDir string `json:"sharedDir"`
 }
 
 // RosettaShare configures rosetta support in the guest to run Intel binaries on Apple CPUs
 type RosettaShare struct {
 	DirectorySharingConfig
-	InstallRosetta bool
+	InstallRosetta bool `json:"installRosetta"`
 }
 
 // NVMExpressController configures a NVMe controller in the guest
@@ -91,19 +91,19 @@ type VirtioRng struct {
 
 // VirtioNet configures the virtual machine networking.
 type VirtioNet struct {
-	Nat        bool
-	MacAddress net.HardwareAddr
+	Nat        bool             `json:"nat"`
+	MacAddress net.HardwareAddr `json:"macAddress"`
 	// file parameter is holding a connected datagram socket.
 	// see https://github.com/Code-Hex/vz/blob/7f648b6fb9205d6f11792263d79876e3042c33ec/network.go#L113-L155
-	Socket *os.File
+	Socket *os.File `json:"socket"`
 
-	UnixSocketPath string
+	UnixSocketPath string `json:"unixSocketPath"`
 }
 
 // VirtioSerial configures the virtual machine serial ports.
 type VirtioSerial struct {
-	LogFile   string
-	UsesStdio bool
+	LogFile   string `json:"logFile"`
+	UsesStdio bool   `json:"usesStdio"`
 }
 
 // TODO: Add VirtioBalloon
@@ -676,9 +676,9 @@ func USBMassStorageNew(imagePath string) (VMComponent, error) {
 
 // StorageConfig configures a disk device.
 type StorageConfig struct {
-	DevName   string
-	ImagePath string
-	ReadOnly  bool
+	DevName   string `json:"devName"`
+	ImagePath string `json:"imagePath"`
+	ReadOnly  bool   `json:"readOnly"`
 }
 
 func (config *StorageConfig) ToCmdLine() ([]string, error) {

--- a/pkg/rest/define/config.go
+++ b/pkg/rest/define/config.go
@@ -1,11 +1,36 @@
 package define
 
+import (
+	"github.com/crc-org/vfkit/pkg/config"
+)
+
+type VirtioNetResponse struct {
+	Nat            bool   `json:"nat"`
+	MacAddress     string `json:"macAddress"`
+	UnixSocketPath string `json:"unixSocketPath"`
+	Fd             int    `json:"fd"`
+}
+
+type DevicesResponse struct {
+	Input          []config.VirtioInput          `json:"input"`
+	GPU            []config.VirtioGPU            `json:"gpu"`
+	Vsock          []config.VirtioVsock          `json:"vsock"`
+	Blk            []config.VirtioBlk            `json:"blk"`
+	FS             []config.VirtioFs             `json:"fs"`
+	Rosetta        config.RosettaShare           `json:"rosetta"`
+	NVMe           []config.NVMExpressController `json:"nvme"`
+	Net            []VirtioNetResponse           `json:"net"`
+	Rng            bool                          `json:"rng"`
+	Serial         config.VirtioSerial           `json:"serial"`
+	USBMassStorage []config.USBMassStorage       `json:"usbMassStorage"`
+}
+
 // InspectResponse is used when responding to a request for
 // information about the virtual machine
 type InspectResponse struct {
-	CPUs   uint   `json:"cpus"`
-	Memory uint64 `json:"memory"`
-	// Devices []config.VirtioDevice `json:"devices"`
+	CPUs    uint            `json:"cpus"`
+	Memory  uint64          `json:"memory"`
+	Devices DevicesResponse `json:"devices"`
 }
 
 // VMState can be used to describe the current state of a VM


### PR DESCRIPTION
Add the correct cpus, memory, devices

**Test Code:**
```golang
package main

import (
	"os"
	"sync"

	"github.com/crc-org/vfkit/pkg/config"
	"github.com/crc-org/vfkit/pkg/rest/define"
	"github.com/gin-gonic/gin"
)

var (
	once            sync.Once
	devicesResponse define.DevicesResponse
)

func devicesToResp(devices []config.VirtioDevice) define.DevicesResponse {
	once.Do(func() {
		for _, dev := range devices {
			switch d := dev.(type) {
			case *config.USBMassStorage:
				devicesResponse.USBMassStorage = append(devicesResponse.USBMassStorage, *d)
			case *config.VirtioBlk:
				devicesResponse.Blk = append(devicesResponse.Blk, *d)
			case *config.RosettaShare:
				devicesResponse.Rosetta = *d
			case *config.NVMExpressController:
				devicesResponse.NVMe = append(devicesResponse.NVMe, *d)
			case *config.VirtioFs:
				devicesResponse.FS = append(devicesResponse.FS, *d)
			case *config.VirtioNet:
				n := define.VirtioNetResponse{
					Nat:            d.Nat,
					MacAddress:     d.MacAddress.String(),
					UnixSocketPath: d.UnixSocketPath,
				}

				if d.Socket != nil {
					n.Fd = int(d.Socket.Fd())
				}

				devicesResponse.Net = append(devicesResponse.Net, n)
			case *config.VirtioRng:
				devicesResponse.Rng = true
			case *config.VirtioSerial:
				devicesResponse.Serial = *d
			case *config.VirtioVsock:
				devicesResponse.Vsock = append(devicesResponse.Vsock, *d)
			case *config.VirtioInput:
				devicesResponse.Input = append(devicesResponse.Input, *d)
			case *config.VirtioGPU:
				devicesResponse.GPU = append(devicesResponse.GPU, *d)
			}
		}
	})

	return devicesResponse
}

func Inspect(devices []config.VirtioDevice) define.InspectResponse {
	ii := define.InspectResponse{
		Devices: devicesToResp(devices),
	}
	return ii
}

func main() {
	eng := gin.Default()
	eng.GET("/inspect", func(c *gin.Context) {
		var devs []config.VirtioDevice

		usb, _ := func() (config.VirtioDevice, error) { return config.USBMassStorageNew("/usb1") }()
		usb2, _ := func() (config.VirtioDevice, error) { return config.USBMassStorageNew("/usb2") }()
		blk, _ := func() (config.VirtioDevice, error) { return config.VirtioBlkNew("/a") }()
		blk2 := &config.VirtioBlk{
			StorageConfig: config.StorageConfig{
				ImagePath: "/b",
				DevName:   "virtio-blk",
			},
			DeviceIdentifier: "/vdd",
		}
		rosetta, _ := func() (config.VirtioDevice, error) { return config.RosettaShareNew("/rosetta") }()
		nvme, _ := func() (config.VirtioDevice, error) { return config.NVMExpressControllerNew("/nvme1") }()
		nvme2, _ := func() (config.VirtioDevice, error) { return config.NVMExpressControllerNew("/nvme2") }()
		fs, _ := func() (config.VirtioDevice, error) { return config.VirtioFsNew("/fs1", "") }()
		fs2, _ := func() (config.VirtioDevice, error) { return config.VirtioFsNew("/fs2", "foo") }()
		net, _ := func() (config.VirtioDevice, error) { return config.VirtioNetNew("4a:f7:a9:77:38:d8") }()
		net2 := &config.VirtioNet{
			UnixSocketPath: "/tmp/unix.sock",
		}
		f, _ := os.CreateTemp(os.TempDir(), "tmp")
		net3 := &config.VirtioNet{
			Socket:     f,
			MacAddress: []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
		}
		rng, _ := func() (config.VirtioDevice, error) { return config.VirtioRngNew() }()
		serial, _ := func() (config.VirtioDevice, error) { return config.VirtioSerialNew("/serial") }()
		vsock, _ := func() (config.VirtioDevice, error) { return config.VirtioVsockNew(1234, "/vsock", false) }()
		vsock2, _ := func() (config.VirtioDevice, error) { return config.VirtioVsockNew(1235, "/vsock2", true) }()
		input, _ := func() (config.VirtioDevice, error) { return config.VirtioInputNew(config.VirtioInputPointingDevice) }()
		input2, _ := func() (config.VirtioDevice, error) { return config.VirtioInputNew(config.VirtioInputKeyboardDevice) }()
		gpu, _ := func() (config.VirtioDevice, error) { return config.VirtioGPUNew() }()
		gpu2 := &config.VirtioGPU{
			UsesGUI: true,
			VirtioGPUResolution: config.VirtioGPUResolution{
				Width:  100,
				Height: 200,
			},
		}

		devs = append(devs,
			usb,
			usb2,
			blk,
			blk2,
			rosetta,
			nvme,
			nvme2,
			fs,
			fs2,
			net,
			net2,
			net3,
			rng,
			serial,
			vsock,
			vsock2,
			input,
			input2,
			gpu,
			gpu2,
		)

		x := Inspect(devs)
		c.JSON(200, x)
	})

	eng.Run(":7777")
}
```

**Result:**

> `curl http://127.0.0.1:7777/inspect`

```json
{
  "cpus": 0,
  "memory": 0,
  "devices": {
    "input": [
      {
        "kind": "virtioinput",
        "inputType": "pointing"
      },
      {
        "kind": "virtioinput",
        "inputType": "keyboard"
      }
    ],
    "gpu": [
      {
        "kind": "virtiogpu",
        "usesGUI": false,
        "width": 800,
        "height": 600
      },
      {
        "kind": "virtiogpu",
        "usesGUI": true,
        "width": 100,
        "height": 200
      }
    ],
    "vsock": [
      {
        "kind": "virtiosock",
        "port": 1234,
        "socketURL": "/vsock",
        "listen": false
      },
      {
        "kind": "virtiosock",
        "port": 1235,
        "socketURL": "/vsock2",
        "listen": true
      }
    ],
    "blk": [
      {
        "kind": "virtioblk",
        "devName": "virtio-blk",
        "imagePath": "/a",
        "readOnly": false,
        "deviceIdentifier": ""
      },
      {
        "kind": "virtioblk",
        "devName": "virtio-blk",
        "imagePath": "/b",
        "readOnly": false,
        "deviceIdentifier": "/vdd"
      }
    ],
    "fs": [
      {
        "kind": "virtiofs",
        "mountTag": "",
        "sharedDir": "/fs1"
      },
      {
        "kind": "virtiofs",
        "mountTag": "foo",
        "sharedDir": "/fs2"
      }
    ],
    "rosetta": {
      "mountTag": "/rosetta",
      "installRosetta": false
    },
    "nvme": [
      {
        "kind": "nvme",
        "devName": "nvme",
        "imagePath": "/nvme1",
        "readOnly": false
      },
      {
        "kind": "nvme",
        "devName": "nvme",
        "imagePath": "/nvme2",
        "readOnly": false
      }
    ],
    "net": [
      {
        "nat": true,
        "macAddress": "4a:f7:a9:77:38:d8",
        "unixSocketPath": "",
        "fd": 0
      },
      {
        "nat": false,
        "macAddress": "",
        "unixSocketPath": "/tmp/unix.sock",
        "fd": 0
      },
      {
        "nat": false,
        "macAddress": "00:11:22:33:44:55",
        "unixSocketPath": "",
        "fd": 9
      }
    ],
    "rng": true,
    "serial": {
      "logFile": "/serial",
      "usesStdio": false
    },
    "usbMassStorage": [
      {
        "kind": "usbmassstorage",
        "devName": "usb-mass-storage",
        "imagePath": "/usb1",
        "readOnly": false
      },
      {
        "kind": "usbmassstorage",
        "devName": "usb-mass-storage",
        "imagePath": "/usb2",
        "readOnly": false
      }
    ]
  }
}
```