### PR TITLE
virtio: Enable full disk caching

### DIFF
--- a/pkg/vf/virtio.go
+++ b/pkg/vf/virtio.go
@@ -275,7 +275,9 @@ func (config *StorageConfig) toVz() (vz.StorageDeviceAttachment, error) {
 	if config.ImagePath == "" {
 		return nil, fmt.Errorf("missing mandatory 'path' option for %s device", config.DevName)
 	}
-	return vz.NewDiskImageStorageDeviceAttachment(config.ImagePath, config.ReadOnly)
+	syncMode := vz.DiskImageSynchronizationModeFsync
+	caching := vz.DiskImageCachingModeCached
+	return vz.NewDiskImageStorageDeviceAttachmentWithCacheAndSync(config.ImagePath, config.ReadOnly, caching, syncMode)
 }
 
 func (dev *USBMassStorage) toVz() (vz.StorageDeviceConfiguration, error) {


### PR DESCRIPTION
We're seeing highly reliable disk corruption in podman machine with the default configuration, and this
fixes it for me.

This looks like the same thing as
https://github.com/lima-vm/lima/commit/488c95c41c67ae0c3afa8f35173a6e1ef59d29ef