### PR TITLE
Add support for nvme devices

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -158,6 +158,23 @@ This adds a virtio-blk device to the VM which will be backed by the raw image at
 ```
 
 
+### NVM Express
+
+#### Description
+
+The `--device nvme` option adds a NVMe device to the virtual machine. The disk is backed by an image file on the host machine. This file is a raw image file.
+
+#### Arguments
+- `path`: the absolute path to the disk image file.
+
+#### Example
+
+This adds a NVMe device to the VM which will be backed by the disk image at `/Users/virtuser/image.img`:
+```
+--device nvme,path=/Users/virtuser/image.img
+```
+
+
 ### USB Mass Storage
 
 #### Description

--- a/pkg/config/json.go
+++ b/pkg/config/json.go
@@ -25,6 +25,7 @@ const (
 	vfGpu          vmComponentKind = "virtiogpu"
 	vfInput        vmComponentKind = "virtioinput"
 	usbMassStorage vmComponentKind = "usbmassstorage"
+	nvme           vmComponentKind = "nvme"
 	rosetta        vmComponentKind = "rosetta"
 )
 
@@ -107,6 +108,10 @@ func unmarshalDevice(rawMsg json.RawMessage) (VirtioDevice, error) {
 		dev = &newDevice
 	case vfBlk:
 		var newDevice VirtioBlk
+		err = json.Unmarshal(rawMsg, &newDevice)
+		dev = &newDevice
+	case nvme:
+		var newDevice NVMExpressController
 		err = json.Unmarshal(rawMsg, &newDevice)
 		dev = &newDevice
 	case vfFs:
@@ -255,6 +260,17 @@ func (dev *VirtioFs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(devWithKind{
 		jsonKind: kind(vfFs),
 		VirtioFs: *dev,
+	})
+}
+
+func (dev *NVMExpressController) MarshalJSON() ([]byte, error) {
+	type devWithKind struct {
+		jsonKind
+		NVMExpressController
+	}
+	return json.Marshal(devWithKind{
+		jsonKind:             kind(nvme),
+		NVMExpressController: *dev,
 	})
 }
 

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -77,6 +77,11 @@ type RosettaShare struct {
 	InstallRosetta bool
 }
 
+// NVMExpressController configures a NVMe controller in the guest
+type NVMExpressController struct {
+	StorageConfig
+}
+
 // virtioRng configures a random number generator (RNG) device.
 type VirtioRng struct {
 }
@@ -143,6 +148,8 @@ func deviceFromCmdLine(deviceOpts string) (VirtioDevice, error) {
 	switch opts[0] {
 	case "rosetta":
 		dev = &RosettaShare{}
+	case "nvme":
+		dev = nvmExpressControllerNewEmpty()
 	case "virtio-blk":
 		dev = virtioBlkNewEmpty()
 	case "virtio-fs":
@@ -450,6 +457,23 @@ func (dev *VirtioRng) FromOptions(options []option) error {
 		return fmt.Errorf("unknown options for virtio-rng devices: %s", options)
 	}
 	return nil
+}
+
+func nvmExpressControllerNewEmpty() *NVMExpressController {
+	return &NVMExpressController{
+		StorageConfig: StorageConfig{
+			DevName: "nvme",
+		},
+	}
+}
+
+// NVMExpressControllerNew creates a new NVMExpress controller to use in the
+// virtual machine. It will use the file at imagePath as the disk image. This
+// image must be in raw format.
+func NVMExpressControllerNew(imagePath string) (*NVMExpressController, error) {
+	r := nvmExpressControllerNewEmpty()
+	r.ImagePath = imagePath
+	return r, nil
 }
 
 func virtioBlkNewEmpty() *VirtioBlk {

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -45,6 +45,16 @@ var virtioDevTests = map[string]virtioDevTest{
 		expectedCmdLine:  []string{"--device", "virtio-blk,path=/foo/bar,deviceId=test"},
 		alternateCmdLine: []string{"--device", "virtio-blk,deviceId=test,path=/foo/bar"},
 	},
+	"NewNVMe": {
+		newDev: func() (VirtioDevice, error) { return NVMExpressControllerNew("/foo/bar") },
+		expectedDev: &NVMExpressController{
+			StorageConfig: StorageConfig{
+				DevName:   "nvme",
+				ImagePath: "/foo/bar",
+			},
+		},
+		expectedCmdLine: []string{"--device", "nvme,path=/foo/bar"},
+	},
 	"NewVirtioFs": {
 		newDev: func() (VirtioDevice, error) { return VirtioFsNew("/foo/bar", "") },
 		expectedDev: &VirtioFs{


### PR DESCRIPTION
This also seems to avoid the disk corruption that we see with virtio-blk; it reportedly has a small performance hit for raw speed, but I think avoiding the double caching (guest and host) is much better from a performance perspective.