### PR TITLE
ghactions: Trigger snyk on 'pull-request, rather than 'push'

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,5 +1,7 @@
 name: Code Scanning with Snyk
-on: push
+on:
+  pull_request:
+    types: [opened, reopened]
 jobs:
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should fix this error on PRs from dependabot:

```
Error: Workflows triggered by Dependabot on the "push" event run with
read-only access. Uploading Code Scanning results requires write access.
To use Code Scanning with Dependabot, please ensure you are using the
"pull_request" event for this workflow and avoid triggering on the
"push" event for Dependabot branches. See
https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push
for more information on how to configure these events.
```