### PR TITLE
Make e2e tests more robust

### DIFF
--- a/test/vm_helpers.go
+++ b/test/vm_helpers.go
@@ -3,9 +3,11 @@ package test
 import (
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -71,12 +73,19 @@ type vfkitRunner struct {
 func startVfkit(t *testing.T, vm *config.VirtualMachine) *vfkitRunner {
 	const vfkitRelativePath = "../out/vfkit"
 
+	logFilePath := filepath.Join(t.TempDir(), fmt.Sprintf("%s.log", strings.ReplaceAll(t.Name(), "/", "")))
+	logFile, err := os.Create(logFilePath)
+	require.NoError(t, err)
+	log.Infof("vfkit log file: %s", logFilePath)
+
 	binaryPath, err := exec.LookPath(vfkitRelativePath)
 	require.NoError(t, err)
 
 	log.Infof("starting %s", binaryPath)
 	vfkitCmd, err := vm.Cmd(binaryPath)
 	require.NoError(t, err)
+	vfkitCmd.Stdout = logFile
+	vfkitCmd.Stderr = logFile
 
 	err = vfkitCmd.Start()
 	require.NoError(t, err)

--- a/test/vm_test.go
+++ b/test/vm_test.go
@@ -228,6 +228,20 @@ var pciidMacOS13Tests = map[string]pciidTest{
 	},
 }
 
+var pciidMacOS14Tests = map[string]pciidTest{
+	"nvm-express": {
+		vendorID: 0x106b, // Apple
+		deviceID: 0x1a09,
+		createDev: func(t *testing.T) (config.VirtioDevice, error) {
+			diskimg := filepath.Join(t.TempDir(), "nvmexpress.img")
+			f, err := os.Create(diskimg)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+			return config.NVMExpressControllerNew(diskimg)
+		},
+	},
+}
+
 func testPCIId(t *testing.T, test pciidTest, provider OsProvider) {
 	vm := NewTestVM(t, provider)
 	defer vm.Close(t)
@@ -265,6 +279,16 @@ func TestPCIIds(t *testing.T) {
 		}
 	} else {
 		t.Log("Skipping macOS 13 tests")
+	}
+
+	if err := macOSAvailable(14); err == nil {
+		for name, test := range pciidMacOS14Tests {
+			t.Run(name, func(t *testing.T) {
+				testPCIId(t, test, puipuiProvider)
+			})
+		}
+	} else {
+		t.Log("Skipping macOS 14 tests")
 	}
 }
 

--- a/test/vm_test.go
+++ b/test/vm_test.go
@@ -242,6 +242,11 @@ var pciidMacOS14Tests = map[string]pciidTest{
 	},
 }
 
+var pciidVersionedTests = map[int]map[string]pciidTest{
+	13: pciidMacOS13Tests,
+	14: pciidMacOS14Tests,
+}
+
 func testPCIId(t *testing.T, test pciidTest, provider OsProvider) {
 	vm := NewTestVM(t, provider)
 	defer vm.Close(t)
@@ -271,24 +276,16 @@ func TestPCIIds(t *testing.T) {
 		})
 	}
 
-	if err := macOSAvailable(13); err == nil {
-		for name, test := range pciidMacOS13Tests {
-			t.Run(name, func(t *testing.T) {
-				testPCIId(t, test, puipuiProvider)
-			})
+	for macosVersion, tests := range pciidVersionedTests {
+		if err := macOSAvailable(float64(macosVersion)); err == nil {
+			for name, test := range tests {
+				t.Run(name, func(t *testing.T) {
+					testPCIId(t, test, puipuiProvider)
+				})
+			}
+		} else {
+			t.Logf("Skipping macOS %d tests", macosVersion)
 		}
-	} else {
-		t.Log("Skipping macOS 13 tests")
-	}
-
-	if err := macOSAvailable(14); err == nil {
-		for name, test := range pciidMacOS14Tests {
-			t.Run(name, func(t *testing.T) {
-				testPCIId(t, test, puipuiProvider)
-			})
-		}
-	} else {
-		t.Log("Skipping macOS 14 tests")
 	}
 }
 


### PR DESCRIPTION
Initial goal of this PR was to add a NVME test.
However, it initially failed and this was quite hard to debug.
This PR reworks the code in test/ to make unexpected failures easier to catch.