### PR TITLE
gh: Stop using macos11 runners

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -25,6 +25,7 @@ jobs:
         os:
         - macOS-12
         - macOS-13
+        - macOS-14
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -44,11 +45,12 @@ jobs:
       - name: Build
         run: make
       - name: Test
+        if: matrix.os != 'macOS-14'
         run: make test
       - name: vet
         run: go vet ./...
       - name: Upload vfkit artifact
-        if: matrix.os == 'macOS-13'
+        if: matrix.os == 'macOS-14'
         uses: actions/upload-artifact@v4
         with:
           name: Unsigned vfkit Universal Binary

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macOS-11
         - macOS-12
         - macOS-13
     steps:
@@ -45,7 +44,6 @@ jobs:
       - name: Build
         run: make
       - name: Test
-        if: matrix.os != 'macOS-11'
         run: make test
       - name: vet
         run: go vet ./...


### PR DESCRIPTION
This removes the macos11 usage from github actions, and starts using macos14
macos11 runners are deprecated or removed from github actions:
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/
