### PR TITLE
Add readonly option for storage devices

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -183,12 +183,13 @@ The `--device usb-mass-storage` option adds a USB mass storage device to the vir
 
 #### Arguments
 - `path`: the absolute path to the disk image file.
+- `readonly`: if specified the device will be read only.
 
 #### Example
 
-This adds a USB mass storage device to the VM which will be backed by the ISO image at `/Users/virtuser/distro.iso`:
+This adds a read only USB mass storage device to the VM which will be backed by the ISO image at `/Users/virtuser/distro.iso`:
 ```
---device usb-mass-storage,path=/Users/virtuser/distro.iso
+--device usb-mass-storage,path=/Users/virtuser/distro.iso,readonly
 ```
 
 

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -156,6 +156,7 @@ var jsonTests = map[string]jsonTest{
 			// USB mass storage
 			usb, err := USBMassStorageNew("/usbmassstorage")
 			require.NoError(t, err)
+			usb.SetReadOnly(true)
 			// rosetta
 			rosetta, err := RosettaShareNew("vz-rosetta")
 			require.NoError(t, err)
@@ -164,7 +165,7 @@ var jsonTests = map[string]jsonTest{
 
 			return vm
 		},
-		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage"},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false}]}`,
+		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":true},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false}]}`,
 	},
 }
 

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -667,11 +667,15 @@ func usbMassStorageNewEmpty() *USBMassStorage {
 
 // USBMassStorageNew creates a new USB disk to use in the virtual machine. It will use
 // the file at imagePath as the disk image. This image must be in raw or ISO format.
-func USBMassStorageNew(imagePath string) (VMComponent, error) {
+func USBMassStorageNew(imagePath string) (*USBMassStorage, error) {
 	usbMassStorage := usbMassStorageNewEmpty()
 	usbMassStorage.ImagePath = imagePath
 
 	return usbMassStorage, nil
+}
+
+func (dev *USBMassStorage) SetReadOnly(readOnly bool) {
+	dev.StorageConfig.ReadOnly = readOnly
 }
 
 // StorageConfig configures a disk device.

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -685,7 +685,11 @@ func (config *StorageConfig) ToCmdLine() ([]string, error) {
 	if config.ImagePath == "" {
 		return nil, fmt.Errorf("%s devices need the path to a disk image", config.DevName)
 	}
-	return []string{"--device", fmt.Sprintf("%s,path=%s", config.DevName, config.ImagePath)}, nil
+	value := fmt.Sprintf("%s,path=%s", config.DevName, config.ImagePath)
+	if config.ReadOnly {
+		value += ",readonly"
+	}
+	return []string{"--device", value}, nil
 }
 
 func (config *StorageConfig) FromOptions(options []option) error {
@@ -693,6 +697,11 @@ func (config *StorageConfig) FromOptions(options []option) error {
 		switch option.key {
 		case "path":
 			config.ImagePath = option.value
+		case "readonly":
+			if option.value != "" {
+				return fmt.Errorf("unexpected value for virtio-blk 'readonly' option: %s", option.value)
+			}
+			config.ReadOnly = true
 		default:
 			return fmt.Errorf("unknown option for %s devices: %s", config.DevName, option.key)
 		}

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -161,6 +161,24 @@ var virtioDevTests = map[string]virtioDevTest{
 		},
 		expectedCmdLine: []string{"--device", "usb-mass-storage,path=/foo/bar"},
 	},
+	"NewUSBMassStorageReadOnly": {
+		newDev: func() (VirtioDevice, error) {
+			dev, err := USBMassStorageNew("/foo/bar")
+			if err != nil {
+				return nil, err
+			}
+			dev.SetReadOnly(true)
+			return dev, err
+		},
+		expectedDev: &USBMassStorage{
+			StorageConfig: StorageConfig{
+				DevName:   "usb-mass-storage",
+				ImagePath: "/foo/bar",
+				ReadOnly:  true,
+			},
+		},
+		expectedCmdLine: []string{"--device", "usb-mass-storage,path=/foo/bar,readonly"},
+	},
 	"NewVirtioInputWithPointingDevice": {
 		newDev: func() (VirtioDevice, error) { return VirtioInputNew("pointing") },
 		expectedDev: &VirtioInput{


### PR DESCRIPTION
The virtio-blk, nvme, and usb-mass-storage devices can use now `readonly` option to create a read only device. This exposes the exiting StorageConfig.ReadOnly field.

Because this option is mostly useful to cdrom images, document the option only for usb-mass-storage.