### PR TITLE
timesync: Fix automatic vsock device creation

### DIFF
--- a/pkg/vf/vm.go
+++ b/pkg/vf/vm.go
@@ -103,6 +103,17 @@ func (cfg *VirtualMachineConfiguration) toVz() (*vz.VirtualMachineConfiguration,
 			return nil, err
 		}
 	}
+	if cfg.config.Timesync != nil && cfg.config.Timesync.VsockPort != 0 {
+		// automatically add the vsock device we'll need for communication over VsockPort
+		vsockDev := VirtioVsock{
+			Port:   cfg.config.Timesync.VsockPort,
+			Listen: false,
+		}
+		if err := vsockDev.AddToVirtualMachineConfig(cfg); err != nil {
+			return nil, err
+		}
+	}
+
 	cfg.SetStorageDevicesVirtualMachineConfiguration(cfg.storageDevicesConfiguration)
 	cfg.SetDirectorySharingDevicesVirtualMachineConfiguration(cfg.directorySharingDevicesConfiguration)
 	cfg.SetPointingDevicesVirtualMachineConfiguration(cfg.pointingDevicesConfiguration)
@@ -114,17 +125,6 @@ func (cfg *VirtualMachineConfiguration) toVz() (*vz.VirtualMachineConfiguration,
 	// len(cfg.socketDevicesConfiguration should be 0 or 1
 	// https://developer.apple.com/documentation/virtualization/vzvirtiosocketdeviceconfiguration?language=objc
 	cfg.SetSocketDevicesVirtualMachineConfiguration(cfg.socketDevicesConfiguration)
-
-	if cfg.config.Timesync != nil && cfg.config.Timesync.VsockPort != 0 {
-		// automatically add the vsock device we'll need for communication over VsockPort
-		vsockDev := VirtioVsock{
-			Port:   cfg.config.Timesync.VsockPort,
-			Listen: false,
-		}
-		if err := vsockDev.AddToVirtualMachineConfig(cfg); err != nil {
-			return nil, err
-		}
-	}
 
 	valid, err := cfg.Validate()
 	if err != nil {


### PR DESCRIPTION
Timesync uses a vsock port for guest/host time synchronization.
When timesync is in use, if the VM has no vsock device, a new one is
automatically added.
However this got broken in commit a5db53d as we were generating the
hypervisor configuration before adding this device.

This means timesync only worked if you had another vsock device
configured.