### PR TITLE
doc: Set minimum supported version to macOS 12

### DIFF
--- a/contrib/scripts/start-crc-bundle.sh
+++ b/contrib/scripts/start-crc-bundle.sh
@@ -1,5 +1,21 @@
 #!/bin/sh
 
+# This script can be used to start a
+# [CRC/OpenShift Local bundle](https://crc.dev/blog/)
+# with vfkit.
+# It expects the bundle to be unpacked in ~/.crc/cache.
+# It creates an overlay for the disk image, the files in ~/.crc/cache are not
+# modified.
+#
+# Once the VM is running, you can connect to it using the `id_*_crc` SSH key
+# in the bundle directory. The default user is `core`.
+# The VM IP can be found in `/var/db/dhcpd_leases` by searching for the VM MAC
+# address (72:20:43:d4:38:62)
+#
+# Example:
+# $ sh contrib/scripts/start-crc-bundle.sh ~/.crc/cache/crc_microshift_vfkit_4.16.7/
+# $ ssh -i ~/.crc/cache/crc_microshift_vfkit_4.16.7/id_ecdsa_crc core@192.168.64.2
+
 set -exu
 
 YQ=${YQ:-yq}

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -5,7 +5,8 @@
 vfkit is a macOS command-line-based hypervisor, which uses [Apple's Virtualization Framework](https://developer.apple.com/documentation/virtualization?language=objc) to run virtual machines.
 You start a virtual machine by running vfkit with a set of arguments describing the virtual machine configuration/hardware.
 When vfkit stops, the virtual machine stops running.
-It requires macOS 11 or newer, and runs on both Intel and Apple silicon Macs.
+It requires macOS 12 or newer, and runs on both Intel and Apple silicon Macs.
+It may build and run on macOS 11, but this platform is no longer tested as it's [out of support](https://endoflife.date/macos).
 File sharing is only available on macOS 12 or newer.
 UEFI boot and graphical user interface support are only available on macOS 13 or newer.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,14 @@
+// Package config provides native go data types to describe a VM configuration
+// (memory, CPUs, bootloader, devices, ...).
+// It's used by vfkit which generates a VirtualMachine instance after parsing
+// its command line using FromOptions().
+// It can also be used by application writers who want to start a VM with
+// vfkit. After creating a VirtualMachine instance with the needed devices,
+// calling VirtualMachine.Cmd() will return an exec.Cmd which can be used
+// to start the virtual machine.
+//
+// This package does not use Code-Hex/vz directly as it must possible to
+// cross-compile code using it.
 package config
 
 import (

--- a/pkg/vf/virtio.go
+++ b/pkg/vf/virtio.go
@@ -13,6 +13,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// vf will define toVZ() and AddToVirtualMachineConfig() methods on these types
+// We alias the types from the config package to avoid duplicating struct
+// definitions between the config and vf packages
 type RosettaShare config.RosettaShare
 type NVMExpressController config.NVMExpressController
 type VirtioBlk config.VirtioBlk

--- a/pkg/vf/vm.go
+++ b/pkg/vf/vm.go
@@ -1,3 +1,10 @@
+// Package vf converts a config.VirtualMachine configuration to native
+// virtualization framework datatypes. It also provides APIs to start/stop/...
+// the virtualization framework virtual machine.
+//
+// The interaction with the virtualization framework is done using the
+// Code-Hex/vz Objective-C bindings. This requires cgo, and this package cannot
+// be easily cross-compiled, it must be built on macOS.
 package vf
 
 import (


### PR DESCRIPTION
macOS 11 github runners are no longer available so we no longer build
and test vfkit on this platform.
macOS 11 has been out of support for a year now.
This commit changes the minimum supported version to macOS 12.
A mention of macOS 11 is kept, we'll remove it when we'll know for sure
vfkit is broken on this platform

This PR also adds some package-level go documentation to (hopefully) make it easier to get into the codebase