### PR TITLE
contrib: update start-crc-bundle to use UEFI boot

### DIFF
--- a/contrib/scripts/start-crc-bundle.sh
+++ b/contrib/scripts/start-crc-bundle.sh
@@ -4,16 +4,11 @@ set -exu
 
 YQ=${YQ:-yq}
 BUNDLE_PATH=$1
-KERNEL=$(cat ${BUNDLE_PATH}/crc-bundle-info.json | ${YQ} .nodes[0].kernel)
-INITRD=$(cat ${BUNDLE_PATH}/crc-bundle-info.json | ${YQ} .nodes[0].initramfs)
-CMDLINE=$(cat ${BUNDLE_PATH}/crc-bundle-info.json | ${YQ} .nodes[0].kernelCmdLine)
 DISKIMG=$(cat ${BUNDLE_PATH}/crc-bundle-info.json | ${YQ} .storage.diskImages[0].name)
 cp -c ${BUNDLE_PATH}/${DISKIMG} overlay.img
 
 ./out/vfkit --cpus 2 --memory 2048 \
-    --kernel "${BUNDLE_PATH}/${KERNEL}" \
-    --initrd "${BUNDLE_PATH}/${INITRD}" \
-    --kernel-cmdline "${CMDLINE}" \
+    --bootloader efi,variable-store=efistore.nvram,create \
     --device virtio-blk,path=overlay.img \
     --device virtio-serial,logFilePath=start-bundle.log \
     --device virtio-net,nat,mac=72:20:43:d4:38:62 \


### PR DESCRIPTION
it removes all the legacy kernel related options (kernel, initrd, kernel-cmdline) and replace them with the --bootloader efi.

I found out that there is an efistore.nvram file inside the `.crc/machine.crc` path. It looks logical to use it but I'm not sure if the path can be different based on the bundle_path or anything else.