### PR TITLE
rosetta: add option to ignore rosetta failure when installation cancelled

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -362,6 +362,7 @@ See https://developer.apple.com/documentation/virtualization/running_intel_binar
 #### Arguments
 - `mountTag`: tag which will be used to mount the rosetta share in the guest.
 - `install`: indicates to automatically install rosetta on systems where it's missing. By default, an error will be reported if `--device rosetta` is used when rosetta is not installed.
+- `ignoreIfMissing`: indicates if vfkit has to keep executing even though rosetta is not installed. It may happen that the user cancels rosetta installation or the installation fails for other reasons. By default, if rosetta installation fails and vfkit cannot find it, vfkit exits with an error.
 
 #### Example
 

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -165,7 +165,7 @@ var jsonTests = map[string]jsonTest{
 
 			return vm
 		},
-		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":true},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false}]}`,
+		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":true},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false,"ignoreIfMissing":false}]}`,
 	},
 }
 
@@ -212,7 +212,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 	},
 	"RosettaShare": {
 		obj:          &RosettaShare{},
-		expectedJSON: `{"kind":"rosetta","mountTag":"MountTag","installRosetta":true}`,
+		expectedJSON: `{"kind":"rosetta","mountTag":"MountTag","installRosetta":true,"ignoreIfMissing":true}`,
 	},
 	"VirtioFs": {
 		obj:          &VirtioFs{},

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -75,7 +75,8 @@ type VirtioFs struct {
 // RosettaShare configures rosetta support in the guest to run Intel binaries on Apple CPUs
 type RosettaShare struct {
 	DirectorySharingConfig
-	InstallRosetta bool `json:"installRosetta"`
+	InstallRosetta  bool `json:"installRosetta"`
+	IgnoreIfMissing bool `json:"ignoreIfMissing"`
 }
 
 // NVMExpressController configures a NVMe controller in the guest
@@ -639,6 +640,9 @@ func (dev *RosettaShare) ToCmdLine() ([]string, error) {
 	if dev.InstallRosetta {
 		builder.WriteString(",install")
 	}
+	if dev.IgnoreIfMissing {
+		builder.WriteString(",ignore-if-missing")
+	}
 
 	return []string{"--device", builder.String()}, nil
 }
@@ -650,6 +654,8 @@ func (dev *RosettaShare) FromOptions(options []option) error {
 			dev.MountTag = option.value
 		case "install":
 			dev.InstallRosetta = true
+		case "ignore-if-missing":
+			dev.IgnoreIfMissing = true
 		default:
 			return fmt.Errorf("unknown option for rosetta share: %s", option.key)
 		}

--- a/pkg/vf/rosetta_arm64_test.go
+++ b/pkg/vf/rosetta_arm64_test.go
@@ -1,0 +1,110 @@
+package vf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Code-Hex/vz/v3"
+	"github.com/crc-org/vfkit/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+type checkRosettaAvailabilityTest struct {
+	installRosetta                         bool
+	ignoreIfMissing                        bool
+	checkRosettaDirectoryShareAvailability func() vz.LinuxRosettaAvailability
+	doInstallRosetta                       func() error
+	errorValue                             string
+}
+
+var checkRosettaAvailabilityTests = map[string]checkRosettaAvailabilityTest{
+	"TestRosettaIsNotSupported": {
+		checkRosettaDirectoryShareAvailability: func() vz.LinuxRosettaAvailability {
+			return vz.LinuxRosettaAvailabilityNotSupported
+		},
+		errorValue: "rosetta is not supported",
+	},
+	"TestRosettaInstalled": {
+		checkRosettaDirectoryShareAvailability: func() vz.LinuxRosettaAvailability {
+			return vz.LinuxRosettaAvailabilityInstalled
+		},
+	},
+	"TestRosettaNotInstalled-NotToBeInstalled": {
+		installRosetta: false,
+		checkRosettaDirectoryShareAvailability: func() vz.LinuxRosettaAvailability {
+			return vz.LinuxRosettaAvailabilityNotInstalled
+		},
+		errorValue: "rosetta is not installed",
+	},
+	"TestRosettaNotInstalled-InstallationCancelledButIgnoreIfMissingFalse": {
+		installRosetta:  true,
+		ignoreIfMissing: false,
+		checkRosettaDirectoryShareAvailability: func() vz.LinuxRosettaAvailability {
+			return vz.LinuxRosettaAvailabilityNotInstalled
+		},
+		doInstallRosetta: func() error {
+			return fmt.Errorf("VZErrorDomain Code=%d", vz.ErrorOperationCancelled)
+		},
+		errorValue: fmt.Sprintf("failed to install rosetta: VZErrorDomain Code=%d", vz.ErrorOperationCancelled),
+	},
+	"TestRosettaNotInstalled-InstallationCancelledButIgnoreIfMissingTrue": {
+		installRosetta:  true,
+		ignoreIfMissing: true,
+		checkRosettaDirectoryShareAvailability: func() vz.LinuxRosettaAvailability {
+			return vz.LinuxRosettaAvailabilityNotInstalled
+		},
+		doInstallRosetta: func() error {
+			return fmt.Errorf("VZErrorDomain Code=%d", vz.ErrorOperationCancelled)
+		},
+	},
+	"TestRosettaNotInstalled-InstallationFailedButIgnoreIfMissingTrue": {
+		installRosetta:  true,
+		ignoreIfMissing: true,
+		checkRosettaDirectoryShareAvailability: func() vz.LinuxRosettaAvailability {
+			return vz.LinuxRosettaAvailabilityNotInstalled
+		},
+		doInstallRosetta: func() error {
+			return fmt.Errorf("VZErrorDomain Code=%d", vz.ErrorInstallationFailed)
+		},
+	},
+}
+
+func TestCheckRosettaAvailability(t *testing.T) {
+	t.Run("name", func(t *testing.T) {
+		for name := range checkRosettaAvailabilityTests {
+			t.Run(name, func(t *testing.T) {
+				test := checkRosettaAvailabilityTests[name]
+				testCheckRosettaAvailability(t, &test)
+			})
+		}
+	})
+}
+
+func testCheckRosettaAvailability(t *testing.T, test *checkRosettaAvailabilityTest) {
+	rosetta :=
+		RosettaShare{
+			InstallRosetta:  test.installRosetta,
+			IgnoreIfMissing: test.ignoreIfMissing,
+			DirectorySharingConfig: config.DirectorySharingConfig{
+				MountTag: "mount",
+			},
+		}
+
+	origCheckRosettaDirectoryShareAvailability := checkRosettaDirectoryShareAvailability
+	checkRosettaDirectoryShareAvailability = test.checkRosettaDirectoryShareAvailability
+	origDoInstallRosetta := doInstallRosetta
+	doInstallRosetta = test.doInstallRosetta
+	defer func() {
+		checkRosettaDirectoryShareAvailability = origCheckRosettaDirectoryShareAvailability
+		doInstallRosetta = origDoInstallRosetta
+	}()
+
+	err := rosetta.checkRosettaAvailability()
+
+	if test.errorValue != "" {
+		require.Error(t, err)
+		require.ErrorContains(t, err, test.errorValue)
+	} else {
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
This adds a ignore-if-missing option that allows vfkit to not fail if the rosetta installation is cancelled by the user.
So far, if the rosetta installation was cancelled vfkit exited with an error. This behavior still exists if ignore-if-missing option is not set.
it fixes #160