### PR TITLE
ignition: add support for ignition config file

### DIFF
--- a/cmd/vfkit/main_test.go
+++ b/cmd/vfkit/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartIgnitionProvisionerServer(t *testing.T) {
+	socketPath := "virtiovsock"
+	defer os.Remove(socketPath)
+
+	ignitionData := []byte("ignition configuration")
+	ignitionReader := bytes.NewReader(ignitionData)
+
+	// Start the server using the socket so that it can returns the ignition data
+	go func() {
+		err := startIgnitionProvisionerServer(ignitionReader, socketPath)
+		require.NoError(t, err)
+	}()
+
+	// Make a request to the server
+	client := http.Client{
+		Transport: &http.Transport{
+			Dial: func(_, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+	resp, err := client.Get("http://unix://" + socketPath)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Verify the response from the server is actually the ignition data
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, ignitionData, body)
+}

--- a/contrib/ignition/README.md
+++ b/contrib/ignition/README.md
@@ -1,0 +1,9 @@
+## Ignition
+
+Ignition uses a JSON configuration file to define the desired changes. The format of this config is specified in detail [here](https://coreos.github.io/ignition/specs/), and its [MIME type](http://www.iana.org/assignments/media-types/application/vnd.coreos.ignition+json) is registered with IANA.
+
+`myconfig.json` file provides an example of configuration that adds a new `testuser`, creates a new file to `/etc/myapp` with the content listed in the same `files` section and add a systemd unit drop-in to modify the existing service `systemd-journald` and sets its environment variable SYSTEMD_LOG_LEVEL to debug.
+
+### Examples
+
+More examples can be found at https://coreos.github.io/ignition/examples/

--- a/contrib/ignition/myconfig.json
+++ b/contrib/ignition/myconfig.json
@@ -1,0 +1,31 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "testuser",
+        "sshAuthorizedKeys": [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO43Z9aRPvvj1zMib/Hh4oWX+MuOPXdFChFMaWfishLj"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "files": [{
+      "path": "/etc/someconfig",
+      "mode": 420,
+      "contents": { "source": "data:,example%20file%0A" }
+    }]
+  },
+  "systemd": {
+    "units": [{
+      "name": "systemd-journald.service",
+      "dropins": [{
+        "name": "debug.conf",
+        "contents": "[Service]\nEnvironment=SYSTEMD_LOG_LEVEL=debug"
+      }]
+    }]
+  }
+}

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -460,3 +460,18 @@ Proper use of this flag may look similar to the following section of a command:
 ```bash
 --device virtio-input,keyboard --device virtio-input,pointing --device virtio-gpu,width=1920,height=1080 --gui
 ```
+
+### Ignition
+
+#### Description
+
+The `--ignition` option allows you to specify a configuration file for Ignition. Vfkit will open a vsock connection between the host and the guest and start a lightweight HTTP server to push the configuration file to Ignition.
+
+You can find example configurations and more details about Ignition at https://coreos.github.io/ignition/ 
+
+#### Example
+
+This command provisions the configuration file to Ignition on the guest
+```
+--ignition configuration-path
+```

--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -23,6 +23,8 @@ type Options struct {
 	LogLevel string
 
 	UseGUI bool
+
+	IgnitionPath string
 }
 
 const DefaultRestfulURI = "none://"
@@ -49,5 +51,7 @@ func AddFlags(cmd *cobra.Command, opts *Options) {
 
 	cmd.Flags().StringVar(&opts.LogLevel, "log-level", "", "set log level")
 	cmd.Flags().StringVar(&opts.RestfulURI, "restful-uri", DefaultRestfulURI, "URI address for RESTful services")
+
+	cmd.Flags().StringVar(&opts.IgnitionPath, "ignition", "", "path to the ignition file")
 
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddIgnitionFile_MultipleOptions(t *testing.T) {
+	vm := &VirtualMachine{}
+	err := vm.AddIgnitionFileFromCmdLine("file1,file2")
+	assert.EqualError(t, err, "ignition only accept one option in command line argument")
+}
+
+func TestAddIgnitionFile_OneOption(t *testing.T) {
+	vm := &VirtualMachine{}
+	err := vm.AddIgnitionFileFromCmdLine("file1")
+	require.NoError(t, err)
+	assert.Len(t, vm.Devices, 1)
+	assert.Equal(t, uint32(ignitionVsockPort), vm.Devices[0].(*VirtioVsock).Port)
+	assert.Equal(t, "file1", vm.Ignition.ConfigPath)
+}

--- a/pkg/config/json.go
+++ b/pkg/config/json.go
@@ -28,6 +28,7 @@ const (
 	usbMassStorage vmComponentKind = "usbmassstorage"
 	nvme           vmComponentKind = "nvme"
 	rosetta        vmComponentKind = "rosetta"
+	ignition       vmComponentKind = "ignition"
 )
 
 type jsonKind struct {
@@ -87,6 +88,17 @@ func unmarshalDevices(rawMsg json.RawMessage) ([]VirtioDevice, error) {
 	}
 
 	return devices, nil
+}
+
+func unmarshalIgnition(rawMsg json.RawMessage) (Ignition, error) {
+	var ignition Ignition
+
+	err := json.Unmarshal(rawMsg, &ignition)
+	if err != nil {
+		return Ignition{}, err
+	}
+
+	return ignition, nil
 }
 
 // VirtioNet needs a custom unmarshaller as net.HardwareAddress is not
@@ -207,6 +219,11 @@ func (vm *VirtualMachine) UnmarshalJSON(b []byte) error {
 			devices, err = unmarshalDevices(*rawMsg)
 			if err == nil {
 				vm.Devices = devices
+			}
+		case "ignition":
+			ignition, err := unmarshalIgnition(*rawMsg)
+			if err == nil {
+				vm.Ignition = &ignition
 			}
 		}
 
@@ -365,5 +382,16 @@ func (dev *USBMassStorage) MarshalJSON() ([]byte, error) {
 	return json.Marshal(devWithKind{
 		jsonKind:       kind(usbMassStorage),
 		USBMassStorage: *dev,
+	})
+}
+
+func (ign *Ignition) MarshalJSON() ([]byte, error) {
+	type devWithKind struct {
+		jsonKind
+		Ignition
+	}
+	return json.Marshal(devWithKind{
+		jsonKind: kind(ignition),
+		Ignition: *ign,
 	})
 }

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -85,6 +85,16 @@ var jsonTests = map[string]jsonTest{
 		},
 		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"timesync":{"vsockPort":1234}}`,
 	},
+	"TestIgnition": {
+		newVM: func(t *testing.T) *VirtualMachine {
+			vm := newLinuxVM(t)
+			ignition, err := IgnitionNew("config", "socket")
+			require.NoError(t, err)
+			vm.Ignition = ignition
+			return vm
+		},
+		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"}, "ignition":{"kind":"ignition","configPath":"config","socketPath":"socket"}}`,
+	},
 	"TestVirtioRNG": {
 		newVM: func(t *testing.T) *VirtualMachine {
 			vm := newLinuxVM(t)
@@ -207,7 +217,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 
 			return vm
 		},
-		skipFields:   []string{"Bootloader", "Devices", "Timesync"},
+		skipFields:   []string{"Bootloader", "Devices", "Timesync", "Ignition"},
 		expectedJSON: `{"vcpus":3,"memoryBytes":3,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","kernelCmdLine":"console=hvc0","initrdPath":"/initrd"},"devices":[{"kind":"virtiorng"}],"timesync":{"vsockPort":1234}}`,
 	},
 	"RosettaShare": {


### PR DESCRIPTION
it adds support to pass an ignition config file to vfkit that handles the provisioning process.

it resolves #124 