### PR TITLE
feat: add support for NBD

### DIFF
--- a/cmd/vfkit/main.go
+++ b/cmd/vfkit/main.go
@@ -189,6 +189,11 @@ func runVirtualMachine(vmConfig *config.VirtualMachine, vm *vf.VirtualMachine) e
 		defer closer.Close()
 	}
 
+	if err := vf.ListenNetworkBlockDevices(vm); err != nil {
+		log.Debugf("%v", err)
+		return err
+	}
+
 	if err := setupGuestTimeSync(vm, vmConfig.TimeSync()); err != nil {
 		log.Warnf("Error configuring guest time synchronization")
 		log.Debugf("%v", err)

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -223,6 +223,28 @@ This adds a read only USB mass storage device to the VM which will be backed by 
 --device usb-mass-storage,path=/Users/virtuser/distro.iso,readonly
 ```
 
+### Network Block Device
+
+#### Description
+
+The `--device nbd` option allows to connect to a remote NBD server, effectively accessing a remote block device over the network as if it were a local disk.
+
+The NBD client running on the VM is informed in case the connection drops and it tries to reconnect automatically to the server.
+
+#### Arguments
+- `uri`: the URI that refers to the NBD server to which the NBD client will connect, e.g. `nbd://10.10.2.8:10000/export`. More info at https://github.com/NetworkBlockDevice/nbd/blob/master/doc/uri.md
+- `deviceId`: `/dev/disk/by-id/virtio-` identifier to use for this device.
+- `sync`: the mode in which the NBD client synchronizes data with the NBD server. It can be `full`or `none`, more info at https://developer.apple.com/documentation/virtualization/vzdisksynchronizationmode?language=objc
+- `timeout`: the timeout value in milliseconds for the connection between the client and server
+- `readonly`: if specified the device will be read only.
+
+#### Example
+
+This allows to connect to the export of the remote NBD server:
+```
+--device nbd,uri=nbd://192.168.64.4:11111/export,deviceId=nbd1,timeout=3000
+```
+
 
 ### Networking
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,16 @@ func (vm *VirtualMachine) VirtioVsockDevices() []*VirtioVsock {
 	return vsockDevs
 }
 
+func (vm *VirtualMachine) NetworkBlockDevice(deviceID string) *NetworkBlockDevice {
+	for _, dev := range vm.Devices {
+		if nbdDev, isNbdDev := dev.(*NetworkBlockDevice); isNbdDev && nbdDev.DeviceIdentifier == deviceID {
+			return nbdDev
+		}
+	}
+
+	return nil
+}
+
 // AddDevice adds a dev to vm. This device can be created with one of the
 // VirtioXXXNew methods.
 func (vm *VirtualMachine) AddDevice(dev VirtioDevice) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -21,3 +21,26 @@ func TestAddIgnitionFile_OneOption(t *testing.T) {
 	assert.Equal(t, uint32(ignitionVsockPort), vm.Devices[0].(*VirtioVsock).Port)
 	assert.Equal(t, "file1", vm.Ignition.ConfigPath)
 }
+
+func TestNetworkBlockDevice(t *testing.T) {
+	vm := &VirtualMachine{}
+	gpu, _ := VirtioGPUNew()
+	vm.Devices = append(vm.Devices, gpu)
+	nbd, _ := NetworkBlockDeviceNew("uri", 1000, SynchronizationFullMode)
+	nbd.DeviceIdentifier = "nbd1"
+	vm.Devices = append(vm.Devices, nbd)
+	nbd2, _ := NetworkBlockDeviceNew("uri2", 1000, SynchronizationFullMode)
+	nbd2.DeviceIdentifier = "nbd2"
+	vm.Devices = append(vm.Devices, nbd2)
+
+	nbdItem := vm.NetworkBlockDevice("nbd2")
+	assert.Equal(t, "nbd2", nbdItem.DeviceIdentifier)
+	assert.Equal(t, "uri2", nbdItem.URI)
+}
+
+func TestNetworkBlockDevice_NoDevice(t *testing.T) {
+	vm := &VirtualMachine{}
+
+	nbdItem := vm.NetworkBlockDevice("nbd2")
+	require.Nil(t, nbdItem)
+}

--- a/pkg/config/json.go
+++ b/pkg/config/json.go
@@ -29,6 +29,7 @@ const (
 	nvme           vmComponentKind = "nvme"
 	rosetta        vmComponentKind = "rosetta"
 	ignition       vmComponentKind = "ignition"
+	vfNbd          vmComponentKind = "nbd"
 )
 
 type jsonKind struct {
@@ -172,6 +173,10 @@ func unmarshalDevice(rawMsg json.RawMessage) (VirtioDevice, error) {
 		dev = &newDevice
 	case usbMassStorage:
 		var newDevice USBMassStorage
+		err = json.Unmarshal(rawMsg, &newDevice)
+		dev = &newDevice
+	case vfNbd:
+		var newDevice NetworkBlockDevice
 		err = json.Unmarshal(rawMsg, &newDevice)
 		dev = &newDevice
 	default:
@@ -393,5 +398,16 @@ func (ign *Ignition) MarshalJSON() ([]byte, error) {
 	return json.Marshal(devWithKind{
 		jsonKind: kind(ignition),
 		Ignition: *ign,
+	})
+}
+
+func (dev *NetworkBlockDevice) MarshalJSON() ([]byte, error) {
+	type devWithKind struct {
+		jsonKind
+		NetworkBlockDevice
+	}
+	return json.Marshal(devWithKind{
+		jsonKind:           kind(vfNbd),
+		NetworkBlockDevice: *dev,
 	})
 }

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -274,7 +274,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 			return blk
 		},
 
-		skipFields:   []string{"DevName"},
+		skipFields:   []string{"DevName", "URI"},
 		expectedJSON: `{"kind":"virtioblk","devName":"virtio-blk","imagePath":"ImagePath","readOnly":true,"deviceIdentifier":"DeviceIdentifier"}`,
 	},
 	"USBMassStorage": {
@@ -283,7 +283,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 			require.NoError(t, err)
 			return usb
 		},
-		skipFields:   []string{"DevName"},
+		skipFields:   []string{"DevName", "URI"},
 		expectedJSON: `{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"ImagePath","readOnly":true}`,
 	},
 	"NVMExpressController": {
@@ -292,7 +292,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 			require.NoError(t, err)
 			return nvme
 		},
-		skipFields:   []string{"DevName"},
+		skipFields:   []string{"DevName", "URI"},
 		expectedJSON: `{"kind":"nvme","devName":"nvme","imagePath":"ImagePath","readOnly":true}`,
 	},
 	"LinuxBootloader": {

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -170,12 +170,15 @@ var jsonTests = map[string]jsonTest{
 			// rosetta
 			rosetta, err := RosettaShareNew("vz-rosetta")
 			require.NoError(t, err)
-			err = vm.AddDevices(fs, usb, rosetta)
+			// NBD
+			nbd, err := NetworkBlockDeviceNew("uri", 1, SynchronizationFullMode)
+			require.NoError(t, err)
+			err = vm.AddDevices(fs, usb, rosetta, nbd)
 			require.NoError(t, err)
 
 			return vm
 		},
-		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":true},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false,"ignoreIfMissing":false}]}`,
+		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":true},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false,"ignoreIfMissing":false},{"kind":"nbd", "devName":"nbd", "uri":"uri", "SynchronizationMode":"full","Timeout":1000000}]}`,
 	},
 }
 
@@ -306,6 +309,15 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 	"TimeSync": {
 		obj:          &TimeSync{},
 		expectedJSON: `{"vsockPort":3}`,
+	},
+	"NetworkBlockDevice": {
+		newObjectFunc: func(t *testing.T) any {
+			nbd, err := NetworkBlockDeviceNew("uri", 1000, SynchronizationFullMode)
+			require.NoError(t, err)
+			return nbd
+		},
+		skipFields:   []string{"DevName", "ImagePath"},
+		expectedJSON: `{"kind":"nbd","deviceIdentifier":"DeviceIdentifier","devName":"nbd","uri":"URI","readOnly":true,"SynchronizationMode":"SynchronizationMode","Timeout":2}`,
 	},
 }
 

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +13,7 @@ type virtioDevTest struct {
 	expectedDev      VirtioDevice
 	expectedCmdLine  []string
 	alternateCmdLine []string
+	errorMsg         string
 }
 
 var virtioDevTests = map[string]virtioDevTest{
@@ -216,6 +218,41 @@ var virtioDevTests = map[string]virtioDevTest{
 		},
 		expectedCmdLine: []string{"--device", "virtio-gpu,width=1920,height=1080"},
 	},
+	"NetworkBlockDeviceNew": {
+		newDev: func() (VirtioDevice, error) {
+			return NetworkBlockDeviceNew("nbd://1.1.1.1:10000", 1000, SynchronizationNoneMode)
+		},
+		expectedDev: &NetworkBlockDevice{
+			VirtioBlk: VirtioBlk{
+				StorageConfig: StorageConfig{
+					DevName: "nbd",
+					URI:     "nbd://1.1.1.1:10000",
+				},
+				DeviceIdentifier: "",
+			},
+			Timeout:             time.Duration(1000 * time.Millisecond),
+			SynchronizationMode: SynchronizationNoneMode,
+		},
+		expectedCmdLine: []string{"--device", "nbd,uri=nbd://1.1.1.1:10000,timeout=1000,sync=none"},
+	},
+	"StorageConfigErrorImageUri": {
+		newDev: func() (VirtioDevice, error) {
+			return &StorageConfig{
+				DevName:   "dev",
+				ImagePath: "path",
+				URI:       "uri",
+			}, nil
+		},
+		errorMsg: "dev devices cannot have both path to a disk image and a uri to a remote block device",
+	},
+	"StorageConfigErrorNoImageOrUri": {
+		newDev: func() (VirtioDevice, error) {
+			return &StorageConfig{
+				DevName: "dev",
+			}, nil
+		},
+		errorMsg: "dev devices need a path to a disk image or a uri to a remote block device",
+	},
 }
 
 func testVirtioDev(t *testing.T, test *virtioDevTest) {
@@ -245,12 +282,25 @@ func testVirtioDev(t *testing.T, test *virtioDevTest) {
 
 }
 
+func testErrorVirtioDev(t *testing.T, test *virtioDevTest) {
+	dev, err := test.newDev()
+	require.NoError(t, err)
+
+	_, err = dev.ToCmdLine()
+	require.Error(t, err)
+	require.EqualError(t, err, test.errorMsg)
+}
+
 func TestVirtioDevices(t *testing.T) {
 	t.Run("virtio-devices", func(t *testing.T) {
 		for name := range virtioDevTests {
 			t.Run(name, func(t *testing.T) {
 				test := virtioDevTests[name]
-				testVirtioDev(t, &test)
+				if test.errorMsg != "" {
+					testErrorVirtioDev(t, &test)
+				} else {
+					testVirtioDev(t, &test)
+				}
 			})
 		}
 


### PR DESCRIPTION
This patch adds support for NBD. The NetworkBlockDevice protocol allows remote block devices to be accessed over the network. By leveraging it we can connect our VM to a remote block device and use it as a local disk.

User can specify the timeout and the synchronization mode (none or full). More info at https://developer.apple.com/documentation/virtualization/vzdisksynchronizationmode?language=objc

It also listens to changes to the network block device attachment, so if there is some connectivity changes (connect, disconnect), the user is informed. To achieve it, it leverages the delegate provided by the Virtualization Framework. More info at https://developer.apple.com/documentation/virtualization/vznetworkblockdevicestoragedeviceattachmentdelegate?language=objc

This feature is only available for macOS 14.0+ and requires an update to the VZ library. So this implementation could be modified based on the work done there.

It needs https://github.com/Code-Hex/vz/pull/156 and https://github.com/Code-Hex/vz/issues/166

It resolves #129 