### PR TITLE
Refactor StorageConfig so it does not have both imagePath and Uri properties

### DIFF
--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -178,7 +178,7 @@ var jsonTests = map[string]jsonTest{
 
 			return vm
 		},
-		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":true},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false,"ignoreIfMissing":false},{"kind":"nbd", "devName":"nbd", "uri":"uri", "SynchronizationMode":"full","Timeout":1000000}]}`,
+		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioserial","logFile":"/virtioserial"},{"kind":"virtioinput","inputType":"keyboard"},{"kind":"virtiogpu","usesGUI":false,"width":800,"height":600},{"kind":"virtionet","nat":true,"macAddress":"00:11:22:33:44:55"},{"kind":"virtiorng"},{"kind":"virtioblk","devName":"virtio-blk","imagePath":"/virtioblk"},{"kind":"virtiosock","port":1234,"socketURL":"/virtiovsock"},{"kind":"virtiofs","mountTag":"tag","sharedDir":"/virtiofs"},{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"/usbmassstorage","readOnly":true},{"kind":"rosetta","mountTag":"vz-rosetta","installRosetta":false,"ignoreIfMissing":false},{"kind":"nbd", "devName":"nbd", "uri":"uri", "DeviceIdentifier":"", "SynchronizationMode":"full","Timeout":1000000}]}`,
 	},
 }
 
@@ -317,7 +317,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 			return nbd
 		},
 		skipFields:   []string{"DevName", "ImagePath"},
-		expectedJSON: `{"kind":"nbd","deviceIdentifier":"DeviceIdentifier","devName":"nbd","uri":"URI","readOnly":true,"SynchronizationMode":"SynchronizationMode","Timeout":2}`,
+		expectedJSON: `{"kind":"nbd","DeviceIdentifier":"DeviceIdentifier","devName":"nbd","uri":"URI","readOnly":true,"SynchronizationMode":"SynchronizationMode","Timeout":2}`,
 	},
 }
 

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -20,8 +20,10 @@ var virtioDevTests = map[string]virtioDevTest{
 	"NewVirtioBlk": {
 		newDev: func() (VirtioDevice, error) { return VirtioBlkNew("/foo/bar") },
 		expectedDev: &VirtioBlk{
-			StorageConfig: StorageConfig{
-				DevName:   "virtio-blk",
+			DiskStorageConfig: DiskStorageConfig{
+				StorageConfig: StorageConfig{
+					DevName: "virtio-blk",
+				},
 				ImagePath: "/foo/bar",
 			},
 			DeviceIdentifier: "",
@@ -38,8 +40,10 @@ var virtioDevTests = map[string]virtioDevTest{
 			return dev, nil
 		},
 		expectedDev: &VirtioBlk{
-			StorageConfig: StorageConfig{
-				DevName:   "virtio-blk",
+			DiskStorageConfig: DiskStorageConfig{
+				StorageConfig: StorageConfig{
+					DevName: "virtio-blk",
+				},
 				ImagePath: "/foo/bar",
 			},
 			DeviceIdentifier: "test",
@@ -50,8 +54,10 @@ var virtioDevTests = map[string]virtioDevTest{
 	"NewNVMe": {
 		newDev: func() (VirtioDevice, error) { return NVMExpressControllerNew("/foo/bar") },
 		expectedDev: &NVMExpressController{
-			StorageConfig: StorageConfig{
-				DevName:   "nvme",
+			DiskStorageConfig: DiskStorageConfig{
+				StorageConfig: StorageConfig{
+					DevName: "nvme",
+				},
 				ImagePath: "/foo/bar",
 			},
 		},
@@ -156,8 +162,10 @@ var virtioDevTests = map[string]virtioDevTest{
 	"NewUSBMassStorage": {
 		newDev: func() (VirtioDevice, error) { return USBMassStorageNew("/foo/bar") },
 		expectedDev: &USBMassStorage{
-			StorageConfig: StorageConfig{
-				DevName:   "usb-mass-storage",
+			DiskStorageConfig: DiskStorageConfig{
+				StorageConfig: StorageConfig{
+					DevName: "usb-mass-storage",
+				},
 				ImagePath: "/foo/bar",
 			},
 		},
@@ -173,10 +181,12 @@ var virtioDevTests = map[string]virtioDevTest{
 			return dev, err
 		},
 		expectedDev: &USBMassStorage{
-			StorageConfig: StorageConfig{
-				DevName:   "usb-mass-storage",
+			DiskStorageConfig: DiskStorageConfig{
+				StorageConfig: StorageConfig{
+					DevName:  "usb-mass-storage",
+					ReadOnly: true,
+				},
 				ImagePath: "/foo/bar",
-				ReadOnly:  true,
 			},
 		},
 		expectedCmdLine: []string{"--device", "usb-mass-storage,path=/foo/bar,readonly"},
@@ -223,35 +233,17 @@ var virtioDevTests = map[string]virtioDevTest{
 			return NetworkBlockDeviceNew("nbd://1.1.1.1:10000", 1000, SynchronizationNoneMode)
 		},
 		expectedDev: &NetworkBlockDevice{
-			VirtioBlk: VirtioBlk{
+			NetworkBlockStorageConfig: NetworkBlockStorageConfig{
 				StorageConfig: StorageConfig{
 					DevName: "nbd",
-					URI:     "nbd://1.1.1.1:10000",
 				},
-				DeviceIdentifier: "",
+				URI: "nbd://1.1.1.1:10000",
 			},
+			DeviceIdentifier:    "",
 			Timeout:             time.Duration(1000 * time.Millisecond),
 			SynchronizationMode: SynchronizationNoneMode,
 		},
 		expectedCmdLine: []string{"--device", "nbd,uri=nbd://1.1.1.1:10000,timeout=1000,sync=none"},
-	},
-	"StorageConfigErrorImageUri": {
-		newDev: func() (VirtioDevice, error) {
-			return &StorageConfig{
-				DevName:   "dev",
-				ImagePath: "path",
-				URI:       "uri",
-			}, nil
-		},
-		errorMsg: "dev devices cannot have both path to a disk image and a uri to a remote block device",
-	},
-	"StorageConfigErrorNoImageOrUri": {
-		newDev: func() (VirtioDevice, error) {
-			return &StorageConfig{
-				DevName: "dev",
-			}, nil
-		},
-		errorMsg: "dev devices need a path to a disk image or a uri to a remote block device",
 	},
 }
 

--- a/pkg/vf/virtio.go
+++ b/pkg/vf/virtio.go
@@ -35,7 +35,7 @@ type vzNetworkBlockDevice struct {
 }
 
 func (dev *NVMExpressController) toVz() (vz.StorageDeviceConfiguration, error) {
-	var storageConfig StorageConfig = StorageConfig(dev.StorageConfig)
+	var storageConfig DiskStorageConfig = DiskStorageConfig(dev.DiskStorageConfig)
 	attachment, err := storageConfig.toVz()
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func (dev *NVMExpressController) AddToVirtualMachineConfig(vmConfig *VirtualMach
 }
 
 func (dev *VirtioBlk) toVz() (vz.StorageDeviceConfiguration, error) {
-	var storageConfig StorageConfig = StorageConfig(dev.StorageConfig)
+	var storageConfig DiskStorageConfig = DiskStorageConfig(dev.DiskStorageConfig)
 	attachment, err := storageConfig.toVz()
 	if err != nil {
 		return nil, err
@@ -431,7 +431,7 @@ func AddToVirtualMachineConfig(vmConfig *VirtualMachineConfiguration, dev config
 	}
 }
 
-func (config *StorageConfig) toVz() (vz.StorageDeviceAttachment, error) {
+func (config *DiskStorageConfig) toVz() (vz.StorageDeviceAttachment, error) {
 	if config.ImagePath == "" {
 		return nil, fmt.Errorf("missing mandatory 'path' option for %s device", config.DevName)
 	}
@@ -441,7 +441,7 @@ func (config *StorageConfig) toVz() (vz.StorageDeviceAttachment, error) {
 }
 
 func (dev *USBMassStorage) toVz() (vz.StorageDeviceConfiguration, error) {
-	var storageConfig StorageConfig = StorageConfig(dev.StorageConfig)
+	var storageConfig DiskStorageConfig = DiskStorageConfig(dev.DiskStorageConfig)
 	attachment, err := storageConfig.toVz()
 	if err != nil {
 		return nil, err
@@ -460,6 +460,6 @@ func (dev *USBMassStorage) AddToVirtualMachineConfig(vmConfig *VirtualMachineCon
 	return nil
 }
 
-type StorageConfig config.StorageConfig
+type DiskStorageConfig config.DiskStorageConfig
 
 type USBMassStorage config.USBMassStorage


### PR DESCRIPTION
https://github.com/crc-org/vfkit/pull/212 introduced a new property to the StorageConfig struct (URI) and, by doing so, now we have to check if we are dealing with a disk storage or a remote disk device by checking imagePath and Uri fields. An idea that came up in https://github.com/crc-org/vfkit/pull/212#discussion_r1854008958 was to refactor the StorageConfig struct to be extended by a DiskStorageConfig and a NetworkBlockStorageConfig.

This PR refactors the code based on that suggestion.