### PR TITLE
add virtio-balloon device

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -161,7 +161,7 @@ A copy-on-write image can be created using `cp -c` or [clonefile(2)](http://www.
 
 The `--device virtio-blk` option can also be used to supply an initial configuration to cloud-init through a disk image.
 
-The ISO image file must be labelled cidata or CIDATA and it must contain the user-data and meta-data files. 
+The ISO image file must be labelled cidata or CIDATA and it must contain the user-data and meta-data files.
 It is also possible to add further configurations by using the network-config and vendor-data files.
 See https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html#runtime-configurations for more details.
 
@@ -313,6 +313,21 @@ This adds a virtio-rng device to the VM:
 --device virtio-rng
 ```
 
+### Memory Balloon
+
+#### Description
+
+The `--device virtio-balloon` option adds a memory balloon device to the virtual machine.
+This device allows dynamic adjustment of guest memory allocation, enabling the host to reclaim memory from the guest
+when needed and return it when available.
+
+#### Example
+
+This adds a virtio-balloon device to the VM:
+
+```
+--device virtio-balloon
+```
 
 ### virtio-vsock communication
 
@@ -509,7 +524,7 @@ Proper use of this flag may look similar to the following section of a command:
 
 The `--ignition` option allows you to specify a configuration file for Ignition. Vfkit will open a vsock connection between the host and the guest and start a lightweight HTTP server to push the configuration file to Ignition.
 
-You can find example configurations and more details about Ignition at https://coreos.github.io/ignition/ 
+You can find example configurations and more details about Ignition at https://coreos.github.io/ignition/
 
 #### Example
 

--- a/pkg/config/json.go
+++ b/pkg/config/json.go
@@ -22,6 +22,7 @@ const (
 	vfBlk          vmComponentKind = "virtioblk"
 	vfFs           vmComponentKind = "virtiofs"
 	vfRng          vmComponentKind = "virtiorng"
+	vfBalloon      vmComponentKind = "virtioballoon"
 	vfSerial       vmComponentKind = "virtioserial"
 	vfGpu          vmComponentKind = "virtiogpu"
 	vfInput        vmComponentKind = "virtioinput"
@@ -157,6 +158,10 @@ func unmarshalDevice(rawMsg json.RawMessage) (VirtioDevice, error) {
 		dev = &newDevice
 	case vfRng:
 		var newDevice VirtioRng
+		err = json.Unmarshal(rawMsg, &newDevice)
+		dev = &newDevice
+	case vfBalloon:
+		var newDevice VirtioBalloon
 		err = json.Unmarshal(rawMsg, &newDevice)
 		dev = &newDevice
 	case vfSerial:
@@ -343,6 +348,17 @@ func (dev *VirtioRng) MarshalJSON() ([]byte, error) {
 	return json.Marshal(devWithKind{
 		jsonKind:  kind(vfRng),
 		VirtioRng: *dev,
+	})
+}
+
+func (dev *VirtioBalloon) MarshalJSON() ([]byte, error) {
+	type devWithKind struct {
+		jsonKind
+		VirtioBalloon
+	}
+	return json.Marshal(devWithKind{
+		jsonKind:      kind(vfBalloon),
+		VirtioBalloon: *dev,
 	})
 }
 

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -106,6 +106,17 @@ var jsonTests = map[string]jsonTest{
 		},
 		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtiorng"}]}`,
 	},
+	"TestVirtioBalloon": {
+		newVM: func(t *testing.T) *VirtualMachine {
+			vm := newLinuxVM(t)
+			virtioBalloon, err := VirtioBalloonNew()
+			require.NoError(t, err)
+			err = vm.AddDevice(virtioBalloon)
+			require.NoError(t, err)
+			return vm
+		},
+		expectedJSON: `{"vcpus":3,"memoryBytes":4194304000,"bootloader":{"kind":"linuxBootloader","vmlinuzPath":"/vmlinuz","initrdPath":"/initrd","kernelCmdLine":"console=hvc0"},"devices":[{"kind":"virtioballoon"}]}`,
+	},
 	"TestMultipleVirtioBlk": {
 		newVM: func(t *testing.T) *VirtualMachine {
 			vm := newLinuxVM(t)

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -123,8 +123,22 @@ type NetworkBlockDevice struct {
 	SynchronizationMode NBDSynchronizationMode
 }
 
-// TODO: Add VirtioBalloon
-// https://github.com/Code-Hex/vz/blob/master/memory_balloon.go
+type VirtioBalloon struct{}
+
+func VirtioBalloonNew() (VirtioDevice, error) {
+	return &VirtioBalloon{}, nil
+}
+
+func (v *VirtioBalloon) FromOptions(options []option) error {
+	if len(options) != 0 {
+		return fmt.Errorf("unknown options for virtio-balloon devices: %s", options)
+	}
+	return nil
+}
+
+func (v *VirtioBalloon) ToCmdLine() ([]string, error) {
+	return []string{"--device", "virtio-balloon"}, nil
+}
 
 type option struct {
 	key   string
@@ -185,6 +199,8 @@ func deviceFromCmdLine(deviceOpts string) (VirtioDevice, error) {
 		dev = &VirtioInput{}
 	case "virtio-gpu":
 		dev = &VirtioGPU{}
+	case "virtio-balloon":
+		dev = &VirtioBalloon{}
 	case "nbd":
 		dev = networkBlockDeviceNewEmpty()
 	default:

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -245,6 +245,11 @@ var virtioDevTests = map[string]virtioDevTest{
 		},
 		expectedCmdLine: []string{"--device", "nbd,uri=nbd://1.1.1.1:10000,timeout=1000,sync=none"},
 	},
+	"NewVirtioBalloon": {
+		newDev:          VirtioBalloonNew,
+		expectedDev:     &VirtioBalloon{},
+		expectedCmdLine: []string{"--device", "virtio-balloon"},
+	},
 }
 
 func testVirtioDev(t *testing.T, test *virtioDevTest) {

--- a/pkg/vf/virtio.go
+++ b/pkg/vf/virtio.go
@@ -27,6 +27,7 @@ type VirtioSerial config.VirtioSerial
 type VirtioVsock config.VirtioVsock
 type VirtioInput config.VirtioInput
 type VirtioGPU config.VirtioGPU
+type VirtioBalloon config.VirtioBalloon
 type NetworkBlockDevice config.NetworkBlockDevice
 
 type vzNetworkBlockDevice struct {
@@ -218,6 +219,21 @@ func (dev *VirtioRng) AddToVirtualMachineConfig(vmConfig *VirtualMachineConfigur
 		return err
 	}
 	vmConfig.entropyDevicesConfiguration = append(vmConfig.entropyDevicesConfiguration, entropyConfig)
+
+	return nil
+}
+
+func (dev *VirtioBalloon) toVz() (*vz.VirtioTraditionalMemoryBalloonDeviceConfiguration, error) {
+	return vz.NewVirtioTraditionalMemoryBalloonDeviceConfiguration()
+}
+
+func (dev *VirtioBalloon) AddToVirtualMachineConfig(vmConfig *VirtualMachineConfiguration) error {
+	log.Infof("Adding virtio-balloon device")
+	balloonConfig, err := dev.toVz()
+	if err != nil {
+		return err
+	}
+	vmConfig.SetMemoryBalloonDevicesVirtualMachineConfiguration([]vz.MemoryBalloonDeviceConfiguration{balloonConfig})
 
 	return nil
 }
@@ -424,6 +440,8 @@ func AddToVirtualMachineConfig(vmConfig *VirtualMachineConfiguration, dev config
 		return (*VirtioInput)(d).AddToVirtualMachineConfig(vmConfig)
 	case *config.VirtioGPU:
 		return (*VirtioGPU)(d).AddToVirtualMachineConfig(vmConfig)
+	case *config.VirtioBalloon:
+		return (*VirtioBalloon)(d).AddToVirtualMachineConfig(vmConfig)
 	case *config.NetworkBlockDevice:
 		return (*NetworkBlockDevice)(d).AddToVirtualMachineConfig(vmConfig)
 	default:

--- a/test/vm_test.go
+++ b/test/vm_test.go
@@ -227,6 +227,13 @@ var pciidTests = map[string]pciidTest{
 			return config.VirtioFsNew("./", "vfkit-share-test")
 		},
 	},
+	"virtio-balloon": {
+		vendorID: 0x1af4, // Red Hat
+		deviceID: 0x1045,
+		createDev: func(_ *testing.T) (config.VirtioDevice, error) {
+			return config.VirtioBalloonNew()
+		},
+	},
 }
 
 var pciidMacOS13Tests = map[string]pciidTest{


### PR DESCRIPTION
The virtio-balloon device is added to the VM when `--device virtio-balloon` is specified. However, I'm not sure how to verify it's actually working inside the VM.

```bash
$ find /sys -iname '*balloon*'
/sys/kernel/btf/virtio_balloon
/sys/bus/virtio/drivers/virtio_balloon
/sys/module/virtio_balloon
/sys/module/virtio_balloon/drivers/virtio:virtio_balloon
```

----

TODOs:

- [x] add test to [vfkit/test/vm_test.go](https://github.com/crc-org/vfkit/blob/9c685bc23f17245bd720aaf3065dd2c66a9cbec8/test/vm_test.go#L201-L230)
- [x] add doc to `usage.md`
- [x] confirm behavior of adding multiple balloon device