### PR TITLE
serial: Add --device virtio-serial,pty support, with ConsoleDeviceConfiguration

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -300,11 +300,12 @@ This is useful in combination with usermode networking stacks such as [gvisor-ta
 #### Description
 
 The `--device virtio-serial` option adds a serial device to the virtual machine. This is useful to redirect text output from the virtual machine to a log file.
-The `logFilePath` and `stdio` arguments are mutually exclusive.
+The `logFilePath`, `stdio`, `pty` arguments are mutually exclusive.
 
 #### Arguments
 - `logFilePath`: path where the serial port output should be written.
 - `stdio`: uses stdin/stdout for the serial console input/output.
+- `pty`: allocates a pseudo-terminal for the serial console input/output.
 
 #### Example
 
@@ -319,6 +320,18 @@ launched from will be used as an interactive serial console for that device:
 --device virtio-serial,stdio
 ```
 
+This adds a virtio-serial device to the VM, and creates a pseudo-terminal for
+the console for that device:
+```
+--device virtio-serial,pty
+```
+Once the VM is running, you can connect to its console with:
+```
+screen /dev/ttys002
+```
+`/dev/ttys002` will vary between `vfkit` runs.
+The `/dev/ttys???` path to the pty is printed during vfkit startup.
+It's also available through the `/vm/inspect` endpoint of [REST API](#restful-service) in the `ptyName` field of the `virtio-serial` device.
 
 ### Random Number Generator
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -300,7 +300,7 @@ This is useful in combination with usermode networking stacks such as [gvisor-ta
 #### Description
 
 The `--device virtio-serial` option adds a serial device to the virtual machine. This is useful to redirect text output from the virtual machine to a log file.
-The `logFilePath`, `stdio`, `pty` arguments are mutually exclusive.
+The `logFilePath`, `stdio` and `pty` arguments are mutually exclusive.
 
 #### Arguments
 - `logFilePath`: path where the serial port output should be written.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/crc-org/crc/v2 v2.47.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/kdomanski/iso9660 v0.4.0
+	github.com/pkg/term v1.1.0
 	github.com/prashantgupta24/mac-sleep-notifier v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/term v1.1.0 h1:xIAAdCMh3QIAy+5FrE8Ad8XoDhEU4ufwbaSozViP9kk=
+github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -143,6 +145,7 @@ golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
 golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -257,7 +257,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 	},
 	"VirtioSerial": {
 		obj:          &VirtioSerial{},
-		expectedJSON: `{"kind":"virtioserial","logFile":"LogFile","usesStdio":true}`,
+		expectedJSON: `{"kind":"virtioserial","logFile":"LogFile","ptyName":"PtyName","usesPty":true,"usesStdio":true}`,
 	},
 	"VirtioVsock": {
 		obj:          &VirtioVsock{},

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -107,6 +107,10 @@ type VirtioNet struct {
 type VirtioSerial struct {
 	LogFile   string `json:"logFile,omitempty"`
 	UsesStdio bool   `json:"usesStdio,omitempty"`
+	UsesPty   bool   `json:"usesPty,omitempty"`
+	// PtyName must not be set when creating the VM, from a user perspective, it's read-only,
+	// vfkit will set it during VM startup.
+	PtyName string `json:"ptyName,omitempty"`
 }
 
 type NBDSynchronizationMode string
@@ -230,12 +234,24 @@ func VirtioSerialNewStdio() (VirtioDevice, error) {
 	}, nil
 }
 
+func VirtioSerialNewPty() (VirtioDevice, error) {
+	return &VirtioSerial{
+		UsesPty: true,
+	}, nil
+}
+
 func (dev *VirtioSerial) validate() error {
 	if dev.LogFile != "" && dev.UsesStdio {
 		return fmt.Errorf("'logFilePath' and 'stdio' cannot be set at the same time")
 	}
-	if dev.LogFile == "" && !dev.UsesStdio {
-		return fmt.Errorf("one of 'logFilePath' or 'stdio' must be set")
+	if dev.LogFile != "" && dev.UsesPty {
+		return fmt.Errorf("'logFilePath' and 'pty' cannot be set at the same time")
+	}
+	if dev.UsesStdio && dev.UsesPty {
+		return fmt.Errorf("'stdio' and 'pty' cannot be set at the same time")
+	}
+	if dev.LogFile == "" && !dev.UsesStdio && !dev.UsesPty {
+		return fmt.Errorf("one of 'logFilePath', 'stdio' or 'pty' must be set")
 	}
 
 	return nil
@@ -245,11 +261,16 @@ func (dev *VirtioSerial) ToCmdLine() ([]string, error) {
 	if err := dev.validate(); err != nil {
 		return nil, err
 	}
-	if dev.UsesStdio {
+	switch {
+	case dev.UsesStdio:
 		return []string{"--device", "virtio-serial,stdio"}, nil
+	case dev.UsesPty:
+		return []string{"--device", "virtio-serial,pty"}, nil
+	case dev.LogFile != "":
+		fallthrough
+	default:
+		return []string{"--device", fmt.Sprintf("virtio-serial,logFilePath=%s", dev.LogFile)}, nil
 	}
-
-	return []string{"--device", fmt.Sprintf("virtio-serial,logFilePath=%s", dev.LogFile)}, nil
 }
 
 func (dev *VirtioSerial) FromOptions(options []option) error {
@@ -262,6 +283,8 @@ func (dev *VirtioSerial) FromOptions(options []option) error {
 				return fmt.Errorf("unexpected value for virtio-serial 'stdio' option: %s", option.value)
 			}
 			dev.UsesStdio = true
+		case "pty":
+			dev.UsesPty = true
 		default:
 			return fmt.Errorf("unknown option for virtio-serial devices: %s", option.key)
 		}

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -128,6 +128,13 @@ var virtioDevTests = map[string]virtioDevTest{
 		},
 		expectedCmdLine: []string{"--device", "virtio-serial,stdio"},
 	},
+	"NewVirtioSerialPty": {
+		newDev: VirtioSerialNewPty,
+		expectedDev: &VirtioSerial{
+			UsesPty: true,
+		},
+		expectedCmdLine: []string{"--device", "virtio-serial,pty"},
+	},
 	"NewVirtioNet": {
 		newDev: func() (VirtioDevice, error) { return VirtioNetNew("") },
 		expectedDev: &VirtioNet{

--- a/pkg/rest/rest.go
+++ b/pkg/rest/rest.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"syscall"
 
 	"github.com/crc-org/vfkit/pkg/cmdline"
+	"github.com/crc-org/vfkit/pkg/util"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -73,6 +75,7 @@ func (v *VFKitService) Start() {
 		case TCP:
 			err = v.router.Run(v.Host)
 		case Unix:
+			util.RegisterExitHandler(func() { os.Remove(v.Path) })
 			err = v.router.RunUnix(v.Path)
 		}
 		logrus.Fatal(err)

--- a/pkg/vf/virtio.go
+++ b/pkg/vf/virtio.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/crc-org/vfkit/pkg/config"
-	"github.com/onsi/gocleanup"
+	"github.com/crc-org/vfkit/pkg/util"
 	"golang.org/x/sys/unix"
 
 	"github.com/Code-Hex/vz/v3"
@@ -248,8 +248,7 @@ func unixFd(fd uintptr) int {
 func setRawMode(f *os.File) error {
 	// Get settings for terminal
 	var attr unix.Termios
-	err := termios.Tcgetattr(f.Fd(), &attr)
-	if err != nil {
+	if err := termios.Tcgetattr(f.Fd(), &attr); err != nil {
 		return err
 	}
 
@@ -271,26 +270,6 @@ func (dev *VirtioSerial) toVz() (*vz.VirtioConsoleDeviceSerialPortConfiguration,
 			return nil, err
 		}
 		serialPortAttachment, retErr = vz.NewFileHandleSerialPortAttachment(os.Stdin, os.Stdout)
-	case dev.UsesPty:
-		master, slave, err := termios.Pty()
-		if err != nil {
-			return nil, err
-		}
-		// as far as I can tell, we have no use for the slave fd in the
-		// vfkit process, the user will open minicom/screen/... /dev/ttys00?
-		// when needed
-		defer slave.Close()
-
-		// the master fd must stay open for vfkit's lifetime
-		gocleanup.Register(func() { _ = master.Close() })
-
-		dev.PtyName = slave.Name()
-
-		if err := setRawMode(master); err != nil {
-			return nil, err
-		}
-		serialPortAttachment, retErr = vz.NewFileHandleSerialPortAttachment(master, master)
-
 	default:
 		serialPortAttachment, retErr = vz.NewFileSerialPortAttachment(dev.LogFile, false)
 	}
@@ -299,6 +278,32 @@ func (dev *VirtioSerial) toVz() (*vz.VirtioConsoleDeviceSerialPortConfiguration,
 	}
 
 	return vz.NewVirtioConsoleDeviceSerialPortConfiguration(serialPortAttachment)
+}
+
+func (dev *VirtioSerial) toVzConsole() (*vz.VirtioConsolePortConfiguration, error) {
+	master, slave, err := termios.Pty()
+	if err != nil {
+		return nil, err
+	}
+
+	// the master fd and slave fd must stay open for vfkit's lifetime
+	util.RegisterExitHandler(func() {
+		_ = master.Close()
+		_ = slave.Close()
+	})
+
+	dev.PtyName = slave.Name()
+
+	if err := setRawMode(master); err != nil {
+		return nil, err
+	}
+	serialPortAttachment, retErr := vz.NewFileHandleSerialPortAttachment(master, master)
+	if retErr != nil {
+		return nil, retErr
+	}
+	return vz.NewVirtioConsolePortConfiguration(
+		vz.WithVirtioConsolePortConfigurationAttachment(serialPortAttachment),
+		vz.WithVirtioConsolePortConfigurationIsConsole(true))
 }
 
 func (dev *VirtioSerial) AddToVirtualMachineConfig(vmConfig *VirtualMachineConfiguration) error {
@@ -312,14 +317,20 @@ func (dev *VirtioSerial) AddToVirtualMachineConfig(vmConfig *VirtualMachineConfi
 		return fmt.Errorf("VirtioSerial.PtyName must be empty (current value: %s)", dev.PtyName)
 	}
 
-	consoleConfig, err := dev.toVz()
-	if err != nil {
-		return err
-	}
 	if dev.UsesPty {
+		consolePortConfig, err := dev.toVzConsole()
+		if err != nil {
+			return err
+		}
+		vmConfig.consolePortsConfiguration = append(vmConfig.consolePortsConfiguration, consolePortConfig)
 		log.Infof("Using PTY (pty path: %s)", dev.PtyName)
+	} else {
+		consoleConfig, err := dev.toVz()
+		if err != nil {
+			return err
+		}
+		vmConfig.serialPortsConfiguration = append(vmConfig.serialPortsConfiguration, consoleConfig)
 	}
-	vmConfig.serialPortsConfiguration = append(vmConfig.serialPortsConfiguration, consoleConfig)
 
 	return nil
 }

--- a/pkg/vf/vm.go
+++ b/pkg/vf/vm.go
@@ -85,6 +85,7 @@ type VirtualMachineConfiguration struct {
 	entropyDevicesConfiguration          []*vz.VirtioEntropyDeviceConfiguration
 	serialPortsConfiguration             []*vz.VirtioConsoleDeviceSerialPortConfiguration
 	socketDevicesConfiguration           []vz.SocketDeviceConfiguration
+	consolePortsConfiguration            []*vz.VirtioConsolePortConfiguration
 }
 
 func NewVirtualMachineConfiguration(vmConfig *config.VirtualMachine) (*VirtualMachineConfiguration, error) {
@@ -129,6 +130,18 @@ func (cfg *VirtualMachineConfiguration) toVz() (*vz.VirtualMachineConfiguration,
 	cfg.SetNetworkDevicesVirtualMachineConfiguration(cfg.networkDevicesConfiguration)
 	cfg.SetEntropyDevicesVirtualMachineConfiguration(cfg.entropyDevicesConfiguration)
 	cfg.SetSerialPortsVirtualMachineConfiguration(cfg.serialPortsConfiguration)
+
+	if len(cfg.consolePortsConfiguration) > 0 {
+		consoleDeviceConfiguration, err := vz.NewVirtioConsoleDeviceConfiguration()
+		if err != nil {
+			return nil, err
+		}
+		for i, portCfg := range cfg.consolePortsConfiguration {
+			consoleDeviceConfiguration.SetVirtioConsolePortConfiguration(i, portCfg)
+		}
+		cfg.SetConsoleDevicesVirtualMachineConfiguration([]vz.ConsoleDeviceConfiguration{consoleDeviceConfiguration})
+	}
+
 	// len(cfg.socketDevicesConfiguration should be 0 or 1
 	// https://developer.apple.com/documentation/virtualization/vzvirtiosocketdeviceconfiguration?language=objc
 	cfg.SetSocketDevicesVirtualMachineConfiguration(cfg.socketDevicesConfiguration)

--- a/test/osprovider.go
+++ b/test/osprovider.go
@@ -193,7 +193,7 @@ func (puipui *PuiPuiProvider) Fetch(destDir string) error {
 		return err
 	}
 	log.Infof("puipui initramfs: %s", puipui.initramfs)
-	puipui.kernelArgs = "console=hvc0"
+	puipui.kernelArgs = "quiet"
 	log.Infof("puipui kernel command line: %s", puipui.kernelArgs)
 
 	return nil

--- a/test/vm_test.go
+++ b/test/vm_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/crc-org/vfkit/pkg/config"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -279,7 +280,7 @@ var pciidVersionedTests = map[int]map[string]pciidTest{
 	14: pciidMacOS14Tests,
 }
 
-func checkRestDevices(t *testing.T, vm *testVM) {
+func restInspect(t *testing.T, vm *testVM) *config.VirtualMachine {
 	tr := &http.Transport{
 		Dial: func(_, _ string) (conn net.Conn, err error) {
 			return net.Dial("unix", vm.restSocketPath)
@@ -294,7 +295,7 @@ func checkRestDevices(t *testing.T, vm *testVM) {
 	var unmarshalledVM config.VirtualMachine
 	err = json.Unmarshal(body, &unmarshalledVM)
 	require.NoError(t, err)
-	require.Equal(t, vm.config, &unmarshalledVM)
+	return &unmarshalledVM
 }
 
 func testPCIId(t *testing.T, test pciidTest, provider OsProvider) {
@@ -310,7 +311,9 @@ func testPCIId(t *testing.T, test pciidTest, provider OsProvider) {
 	vm.Start(t)
 	vm.WaitForSSH(t)
 	checkPCIDevice(t, vm, test.vendorID, test.deviceID)
-	checkRestDevices(t, vm)
+
+	unmarshalledVM := restInspect(t, vm)
+	require.Equal(t, vm.config, unmarshalledVM)
 
 	vm.Stop(t)
 }
@@ -339,6 +342,39 @@ func TestPCIIds(t *testing.T) {
 			t.Logf("Skipping macOS %d tests", macosVersion)
 		}
 	}
+}
+
+func TestVirtioSerialPTY(t *testing.T) {
+	puipuiProvider := NewPuipuiProvider()
+	log.Info("fetching os image")
+	tempDir := t.TempDir()
+	err := puipuiProvider.Fetch(tempDir)
+	require.NoError(t, err)
+
+	vm := NewTestVM(t, puipuiProvider)
+	defer vm.Close(t)
+	require.NotNil(t, vm)
+
+	vm.AddSSH(t, "tcp")
+	dev, err := config.VirtioSerialNewPty()
+	require.NoError(t, err)
+	vm.AddDevice(t, dev)
+
+	vm.Start(t)
+	vm.WaitForSSH(t)
+	runtimeVM := restInspect(t, vm)
+	var foundVirtioSerial bool
+	for _, dev := range runtimeVM.Devices {
+		runtimeDev, ok := dev.(*config.VirtioSerial)
+		if ok {
+			assert.NotEmpty(t, runtimeDev.PtyName)
+			foundVirtioSerial = true
+			break
+		}
+	}
+	require.True(t, foundVirtioSerial)
+
+	vm.Stop(t)
 }
 
 func checkPCIDevice(t *testing.T, vm *testVM, vendorID, deviceID int) {


### PR DESCRIPTION
This PR based on https://github.com/crc-org/vfkit/pull/113
Fixes https://github.com/crc-org/vfkit/issues/48

As @cfergeau suggested PR set 'isConsole' for [VZVirtioConsolePortConfiguration](https://developer.apple.com/documentation/virtualization/vzvirtioconsoleportconfiguration?language=objc)

Also I found that not deleting `slave` file descriptor is increase stability of tty interface, and making connection to tty possible at any time.

And for, some, reason I found that using `minicom` instead of `screen` is more reliable on tty interaction.