### PR TITLE
test: Wait for ignition socket before requesting ignition

### DIFF
--- a/cmd/vfkit/main_test.go
+++ b/cmd/vfkit/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,14 @@ func TestStartIgnitionProvisionerServer(t *testing.T) {
 		err := startIgnitionProvisionerServer(ignitionReader, socketPath)
 		require.NoError(t, err)
 	}()
+
+	// Wait for the socket file to be created before serving, up to 2 seconds
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 
 	// Make a request to the server
 	client := http.Client{


### PR DESCRIPTION
The test sometimes fails with the following error:

Get "http://unix//virtiovsock": dial unix virtiovsock: connect: no such
file or directory

This happens because of a race between the server goroutine and the test
client.

Spotted-At: https://github.com/NixOS/nixpkgs/issues/373493

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
