### PR TITLE
Call exit handlers when process exits normally

### DIFF
--- a/cmd/vfkit/root.go
+++ b/cmd/vfkit/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/crc-org/vfkit/pkg/cmdline"
+	"github.com/crc-org/vfkit/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,9 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		// if vfkit stop execution by itself, i.e. when VM stops by guest OS
+		// we need to call ExecuteExitHandlers to clean up
+		defer util.ExecuteExitHandlers()
 		return runVFKit(vmConfig, opts)
 	},
 	Version: cmdline.Version(),

--- a/pkg/util/exithandler.go
+++ b/pkg/util/exithandler.go
@@ -41,14 +41,20 @@ func setupExitSignalHandling(doExit bool) {
 	go func() {
 		for sig := range sigChan {
 			log.Printf("captured %v, calling exit handlers and exiting..", sig)
-			exitRegistry.mutex.Lock()
-			for _, handler := range exitRegistry.handlers {
-				handler()
-			}
-			exitRegistry.mutex.Unlock()
+			ExecuteExitHandlers()
 			if doExit {
 				os.Exit(1)
 			}
 		}
 	}()
+}
+
+// ExecuteExitHandlers is call all registered exit handlers
+// This function should be called when program finish work(i.e. when VM is turned off by guest OS)
+func ExecuteExitHandlers() {
+	exitRegistry.mutex.Lock()
+	for _, handler := range exitRegistry.handlers {
+		handler()
+	}
+	exitRegistry.mutex.Unlock()
 }

--- a/pkg/vf/virtionet.go
+++ b/pkg/vf/virtionet.go
@@ -59,7 +59,6 @@ func (dev *VirtioNet) connectUnixPath() error {
 	if len(localSocketPath) >= maxUnixgramPathLen {
 		return fmt.Errorf("unixgram path '%s' is too long: %d >= %d bytes", localSocketPath, len(localSocketPath), maxUnixgramPathLen)
 	}
-	// FIXME: need to remove localSocketPath at process exit
 	localAddr := net.UnixAddr{
 		Name: localSocketPath,
 		Net:  "unixgram",


### PR DESCRIPTION
Current implementation in exithandler.go is track only signals(SIGTERM and SIGINT), but vfkit process also could exit normally, when VM is turned off by guest OS. This commit add 'defer util.ExecuteExitHandlers()' call in to root command to call exit handlers when process ending.

Fixes #248