### PR TITLE
Add support for network-config file in cloud-init

### DIFF
--- a/cmd/vfkit/main.go
+++ b/cmd/vfkit/main.go
@@ -289,8 +289,9 @@ func generateCloudInitImage(files []string) (string, error) {
 	}
 
 	configFiles := map[string]io.Reader{
-		"user-data": nil,
-		"meta-data": nil,
+		"user-data":      nil,
+		"meta-data":      nil,
+		"network-config": nil,
 	}
 
 	hasConfigFile := false
@@ -306,7 +307,9 @@ func generateCloudInitImage(files []string) (string, error) {
 
 		filename := filepath.Base(path)
 		if _, ok := configFiles[filename]; ok {
-			hasConfigFile = true
+			if filename == "user-data" || filename == "meta-data" {
+				hasConfigFile = true
+			}
 			configFiles[filename] = file
 		}
 	}

--- a/cmd/vfkit/main_test.go
+++ b/cmd/vfkit/main_test.go
@@ -70,6 +70,7 @@ func TestGenerateCloudInitImage(t *testing.T) {
 	iso, err := generateCloudInitImage([]string{
 		filepath.Join(assetsDir, "user-data"),
 		filepath.Join(assetsDir, "meta-data"),
+		filepath.Join(assetsDir, "network-config"),
 	})
 	require.NoError(t, err)
 

--- a/contrib/scripts/start-with-cloud-init.sh
+++ b/contrib/scripts/start-with-cloud-init.sh
@@ -12,13 +12,16 @@
 # The $DISK_IMG variable needs to be set by the user to a
 # valid image path for the VM.
 #
+# The script has optional support for network-config. The user
+# can specify a network-config file using $NETWORK_CONFIG variable.
+#
 # Once the VM is running, the user can connect to it using their
 # provided key. The VM IP can be found in `/var/db/dhcpd_leases`
 # by searching for the HOST_NAME or MAC address (72:20:43:d4:38:62).
 #
 # Example:
 # $ SSH_USER=test HOST_NAME=vm1 DISK_IMG=Fedora-Cloud-Base-AmazonEC2-41-1.4.aarch64.raw \
-# SSH_PUB_KEY=id_rsa.pub ./contrib/scripts/start-with-cloud-init.sh
+# SSH_PUB_KEY=id_rsa.pub NETWORK_CONFIG=network-config ./contrib/scripts/start-with-cloud-init.sh
 #
 # $ ssh -i id_rsa test@192.168.64.14
 
@@ -26,6 +29,7 @@ set -exu
 
 HOST_NAME=${HOST_NAME:-"vfkit-vm"}
 SSH_USER=${SSH_USER:-"test"}
+NETWORK_CONFIG=${NETWORK_CONFIG:-}
 
 if [ ! -f "$SSH_PUB_KEY" ]; then
   echo "Error: '$SSH_PUB_KEY' does not exist"
@@ -34,6 +38,11 @@ fi
 
 if [ ! -f "$DISK_IMG" ]; then
   echo "Error: '$DISK_IMG' does not exist"
+  exit 1
+fi
+
+if [ -n "$NETWORK_CONFIG" ] && [ ! -f "$NETWORK_CONFIG" ]; then
+  echo "Error: '$NETWORK_CONFIG' does not exist"
   exit 1
 fi
 
@@ -61,9 +70,14 @@ instance-id: $HOST_NAME
 local-hostname: $HOST_NAME
 EOF
 
+CLOUD_INIT_ARGS="out/user-data,out/meta-data"
+if [ -n "$NETWORK_CONFIG" ]; then
+  CLOUD_INIT_ARGS="$CLOUD_INIT_ARGS,$NETWORK_CONFIG"
+fi
+
 ./out/vfkit --cpus 2 --memory 2048 \
     --bootloader efi,variable-store=out/efistore.nvram,create \
-    --cloud-init out/user-data,out/meta-data \
+    --cloud-init "$CLOUD_INIT_ARGS" \
     --device virtio-blk,path="$DISK_IMG" \
     --device virtio-serial,logFilePath=out/cloud-init.log \
     --device virtio-net,nat,mac=72:20:43:d4:38:62 \

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -164,7 +164,7 @@ Vfkit can create this ISO image automatically, or you can provide a pre-made ISO
 
 ##### Automatic ISO Creation
 
-Vfkit allows you to pass the file paths of your `user-data` and `meta-data` files directly as arguments. 
+Vfkit allows you to pass the file paths of your `user-data`, `meta-data`, and `network-config` files directly as arguments.
 It will then handle the creation of the ISO image and the virtio-blk device internally.
 
 Example

--- a/test/assets/network-config
+++ b/test/assets/network-config
@@ -1,0 +1,6 @@
+version: 2
+ethernets:
+  enp0s1:
+    dhcp4: false
+    addresses:
+      - 192.168.64.50/24


### PR DESCRIPTION
This Pull Request does the following:

- Add a "network-config" placeholder in `cloud-init` config to support providing the file to the `cloud-init` option
- Add an optional argument to `start-with-cloud-init.sh` script so it can be run with network-config

FIxes: https://github.com/crc-org/vfkit/issues/296

## Summary by Sourcery

Add optional network configuration support for cloud-init in the VM startup script and configuration

New Features:
- Add support for providing a network-config file when starting a VM with cloud-init

Enhancements:
- Extend the VM startup script to accept an optional network configuration file
- Update cloud-init configuration to support network-config as an optional input