### PR TITLE
Doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,3 @@ brew install vfkit
 ### Building
 
 From the root direction of this repository, run `make`.
-
-### Background
-
-The work in this repository makes use of https://github.com/Code-Hex/vz which provides go bindings for macOS virtualization framework.
-The lifetime of virtual machines created using the virtualization framework is tied to the filetime of the process where they were created.
-When using `Code-Hex/vz`, this means the virtual machine will be terminated at the end of the go process using these bindings.
-Spawning a `vfkit` process gives more flexibility and more control over the lifetime of the virtual machine.
-
-
-The kernel must be uncompressed before use as no bootloader is used, as
-documented in https://www.kernel.org/doc/Documentation/arm64/booting.txt
-
-```
-3. Decompress the kernel image
-------------------------------
-
-Requirement: OPTIONAL
-
-The AArch64 kernel does not currently provide a decompressor and therefore
-requires decompression (gzip etc.) to be performed by the boot loader if a
-compressed Image target (e.g. Image.gz) is used.  For bootloaders that do not
-implement this requirement, the uncompressed Image target is available instead.
-```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ See https://github.com/crc-org/vfkit/blob/main/doc/usage.md
 - [Containers Plumbing 2023](https://crc.dev/blog/posts/2023-03-22-containers-plumbing/)
 - [FOSDEM 2023](https://fosdem.org/2023/schedule/event/govfkit/)
 
+### Adopters
+
+- [minikube](https://minikube.sigs.k8s.io/) 1.35.0 and newer - minikube quickly sets up a local Kubernetes cluster
+- [podman](https://podman.io/) 5.0 and newer - podman is a free software CLI tool to manage containers, pods and images
+- [crc](https://crc.dev/) - crc sets up local OpenShift or MicroShift clusters for development and testing purposes
+- [ovm](https://github.com/oomol-lab/ovm) - ovm is used by Oomol Studio to run linux containers on macOS
+
 ### Installation
 
 vfkit is available in brew:

--- a/README.md
+++ b/README.md
@@ -1,24 +1,11 @@
-vfkit - Simple command line tool to start VMs through the macOS Virtualization framework
+vfkit - Command-line tool to start VMs on macOS
 ====
 
 ### Introduction
 
 vfkit offers a command-line interface to start virtual machines using the [macOS Virtualization framework](https://developer.apple.com/documentation/virtualization).
 It also provides a `github.com/crc-org/vfkit/pkg/config` go package.
-This package provides a native Go API to generate the vfkit command line.
-
-
-### Installation
-
-vfkit is available in brew:
-
-```
-brew install vfkit
-```
-
-### Building
-
-From the root direction of this repository, run `make`.
+This package implements a native Go API to generate the vfkit command line.
 
 ### Usage
 
@@ -31,6 +18,17 @@ See https://github.com/crc-org/vfkit/blob/main/doc/usage.md
 - [Containers Plumbing 2023](https://crc.dev/blog/posts/2023-03-22-containers-plumbing/)
 - [FOSDEM 2023](https://fosdem.org/2023/schedule/event/govfkit/)
 
+### Installation
+
+vfkit is available in brew:
+
+```
+brew install vfkit
+```
+
+### Building
+
+From the root direction of this repository, run `make`.
 
 ### Background
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -288,6 +288,8 @@ This allows to connect to the export of the remote NBD server:
 
 The `--device virtio-net` option adds a network interface to the virtual machine. If it gets its IP address through DHCP, its IP can be found in `/var/db/dhcpd_leases` on the host.
 
+vfkit only supports NAT networking on its own. However, it integrates with [gvisor-tap-vsock](https://github.com/containers/gvisor-tap-vsock) for a user-mode networking stack, and [vmnet-helper](https://github.com/nirs/vmnet-helper) for shared/bridged/host networking through vmnet.
+
 #### Arguments
 - `mac`: optional argument to specify the MAC address of the VM. If it's omitted, a random MAC address will be used.
 - `fd`: file descriptor to attach to the guest network interface. The file descriptor must be a connected datagram socket. See [VZFileHandleNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vzfilehandlenetworkdeviceattachment?language=objc) for more details.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,7 +1,7 @@
 # vfkit Command Line
 
 The `vfkit` executable can be used to create a virtual machine (VM) using macOS virtualization framework.
-The virtual machine will be terminated as soon as the `vfkit` process exits.
+The virtual machine will be started when `vfkit` starts and will be terminated as soon as the `vfkit` process exits.
 Its configuration can be specified through command line options.
 
 Specifying VM bootloader configuration is mandatory.
@@ -54,6 +54,21 @@ A bootloader is required to tell vfkit _how_ it should start the guest OS.
 
 `--bootloader linux` replaces the legacy `--kernel`, `--kernel-cmdline` and `--initrd` options.
 It allows to specify which kernel and initrd should be used when starting the VM.
+
+On Apple Silicon hardware (M1 CPUs and newer), when using `--bootloader linux`, the kernel must be uncompressed before use as documented in https://www.kernel.org/doc/Documentation/arm64/booting.txt. `vfkit` will exit with an error if it detects a compressed kernel when running on Apple silicon. There are no such requirements when using `--bootloader efi`.
+
+Excerpt from the kernel’s `booting.txt`:
+```
+3. Decompress the kernel image
+------------------------------
+
+Requirement: OPTIONAL
+
+The AArch64 kernel does not currently provide a decompressor and therefore
+requires decompression (gzip etc.) to be performed by the boot loader if a
+compressed Image target (e.g. Image.gz) is used.  For bootloaders that do not
+implement this requirement, the uncompressed Image target is available instead.
+```
 
 #### Arguments
 


### PR DESCRIPTION
This adds a list of adopters (podman/minikube/…), and mentions gvisor-tap-vsock and vmnet-helper.

## Summary by Sourcery

Expand project documentation with additional sections and clarifications

Documentation:
- Add Usage section linking to external usage guide
- Add Presentations section listing recent conference talks
- Add Adopters section listing known consumers (minikube, podman, crc, ovm)
- Rename Background to Technical background and clarify kernel bootloader requirements on Apple Silicon
- Include note on integration with gvisor-tap-vsock and vmnet-helper for advanced networking options