### PR TITLE
bump version of tcpproxy to github issue#39

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containers/common v0.62.3
 	github.com/crc-org/crc/v2 v2.49.0
 	github.com/gin-gonic/gin v1.10.0
+	github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048
 	github.com/kdomanski/iso9660 v0.4.0
 	github.com/pkg/term v1.1.0
 	github.com/prashantgupta24/mac-sleep-notifier v1.0.1
@@ -21,7 +22,6 @@ require (
 	golang.org/x/crypto v0.38.0
 	golang.org/x/mod v0.24.0
 	golang.org/x/sys v0.33.0
-	inet.af/tcpproxy v0.0.0-20231102063150-2862066fc2a9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048 h1:jaqViOFFlZtkAwqvwZN+id37fosQqR5l3Oki9Dk4hz8=
+github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048/go.mod h1:Di7LXRyUcnvAcLicFhtM9/MlZl/TNgRSDHORM2c6CMI=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kdomanski/iso9660 v0.4.0 h1:BPKKdcINz3m0MdjIMwS0wx1nofsOjxOq8TOr45WGHFg=
@@ -163,7 +165,5 @@ gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYs
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-inet.af/tcpproxy v0.0.0-20231102063150-2862066fc2a9 h1:zomTWJvjwLbKRgGameQtpK6DNFUbZ2oNJuWhgUkGp3M=
-inet.af/tcpproxy v0.0.0-20231102063150-2862066fc2a9/go.mod h1:Tojt5kmHpDIR2jMojxzZK2w2ZR7OILODmUo2gaSwjrk=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/pkg/vf/vsock.go
+++ b/pkg/vf/vsock.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"inet.af/tcpproxy"
+	"github.com/inetaf/tcpproxy"
 )
 
 func ExposeVsock(vm *VirtualMachine, port uint32, vsockPath string, listen bool) (io.Closer, error) {


### PR DESCRIPTION
Reference:  
https://github.com/inetaf/tcpproxy/issues/39
https://github.com/HarrisonWAffel/wins/blob/3fb03a613c7f045fc9acf0e647c09ef3403410b2/go.mod
  
>> ![image](https://github.com/user-attachments/assets/e70257cd-90c4-4aa2-a9f0-045c3108108d)


```
diff --git a/pkg/vf/vsock.go b/pkg/vf/vsock.go
index 3d03934..8ed9538 100644
--- a/pkg/vf/vsock.go
+++ b/pkg/vf/vsock.go
@@ -8,7 +8,7 @@ import (
        "net/url"
        "strconv"
 
-       "inet.af/tcpproxy"
+       "github.com/inetaf/tcpproxy"
```

Tested:  
```
/src/vfkit/tools/bin"/golangci-lint run
0 issues.
```

```
@ ~/src/vfkit
$ make
CGO_ENABLED=1 CGO_CFLAGS=-mmacosx-version-min=11.0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X github.com/crc-org/vfkit/pkg/cmdline.gitVersion=v0.6.1-26-g465e82c" -o out/vfkit-amd64 ./cmd/vfkit
go: downloading github.com/prashantgupta24/mac-sleep-notifier v1.0.1
go: downloading github.com/sirupsen/logrus v1.9.3
go: downloading github.com/Code-Hex/vz/v3 v3.6.0
go: downloading github.com/spf13/cobra v1.9.1
go: downloading github.com/kdomanski/iso9660 v0.4.0
go: downloading github.com/gin-gonic/gin v1.10.0
go: downloading github.com/containers/common v0.62.3
go: downloading github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048
go: downloading github.com/pkg/term v1.1.0
go: downloading golang.org/x/sys v0.33.0
go: downloading github.com/spf13/pflag v1.0.6
go: downloading github.com/mattn/go-isatty v0.0.20
go: downloading golang.org/x/net v0.37.0
go: downloading github.com/gin-contrib/sse v0.1.0
go: downloading github.com/pelletier/go-toml/v2 v2.2.3
go: downloading github.com/ugorji/go/codec v1.2.12
go: downloading google.golang.org/protobuf v1.36.5
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/go-playground/validator/v10 v10.20.0
go: downloading golang.org/x/mod v0.24.0
go: downloading github.com/Code-Hex/go-infinity-channel v1.0.0
go: downloading golang.org/x/text v0.25.0
go: downloading github.com/gabriel-vasile/mimetype v1.4.3
go: downloading github.com/leodido/go-urn v1.4.0
go: downloading golang.org/x/crypto v0.38.0
go: downloading github.com/go-playground/universal-translator v0.18.1
go: downloading github.com/go-playground/locales v0.14.1
# github.com/crc-org/vfkit/cmd/vfkit
ld: warning: ignoring duplicate libraries: '-lobjc'
codesign -f --entitlements vf.entitlements -s - out/vfkit-amd64
out/vfkit-amd64: replacing existing signature
CGO_ENABLED=1 CGO_CFLAGS=-mmacosx-version-min=11.0 GOOS=darwin GOARCH=arm64 go build -ldflags "-X github.com/crc-org/vfkit/pkg/cmdline.gitVersion=v0.6.1-26-g465e82c" -o out/vfkit-arm64 ./cmd/vfkit
# github.com/crc-org/vfkit/cmd/vfkit
ld: warning: ignoring duplicate libraries: '-lobjc'
codesign -f --entitlements vf.entitlements -s - out/vfkit-arm64
out/vfkit-arm64: replacing existing signature
cd out && lipo -create vfkit-amd64 vfkit-arm64 -output vfkit
```

```
@ ~/src/vfkit
$ out/vfkit --version
vfkit version: v0.6.1-26-g465e82c
```

Feel free to edit as needed. First attempt.

## Summary by Sourcery

Update the tcpproxy module import path and version to resolve GitHub issue #39.

Enhancements:
- Update tcpproxy import path to GitHub-hosted module
- Bump tcpproxy dependency to v0.0.0-20250222171855-c4b9df066048 in go.mod