### PR TITLE
test: fix 10s unreachable timeout in helpers

### DIFF
--- a/test/vm_helpers.go
+++ b/test/vm_helpers.go
@@ -26,6 +26,8 @@ func retryIPFromMAC(errCh chan error, macAddress string) (string, error) {
 		ip  string
 	)
 
+	timeout := time.After(10 * time.Second)
+
 	for {
 		select {
 		case err := <-errCh:
@@ -36,7 +38,7 @@ func retryIPFromMAC(errCh chan error, macAddress string) (string, error) {
 				log.Infof("found IP address %s for MAC %s", ip, macAddress)
 				return ip, nil
 			}
-		case <-time.After(10 * time.Second):
+		case <-timeout:
 			return "", fmt.Errorf("timeout getting IP from MAC: %w", err)
 		}
 	}
@@ -47,6 +49,9 @@ func retrySSHDial(errCh chan error, scheme string, address string, sshConfig *ss
 		sshClient *ssh.Client
 		err       error
 	)
+
+	timeout := time.After(10 * time.Second)
+
 	for {
 		select {
 		case err := <-errCh:
@@ -59,7 +64,7 @@ func retrySSHDial(errCh chan error, scheme string, address string, sshConfig *ss
 				return sshClient, nil
 			}
 			log.Debugf("ssh failed: %v", err)
-		case <-time.After(10 * time.Second):
+		case <-timeout:
 			return nil, fmt.Errorf("timeout waiting for SSH: %w", err)
 		}
 	}


### PR DESCRIPTION
**Problem:** The `10s` timeout channel is created inside the retry loop, making it impossible for it to fire (the `1s` case always wins the select). So the helper retries forever.

**Solution:** Move `timeout := time.After(10 * time.Second)` outside the loop and watch the single channel in the select, so the helper returns an error after any failure beyond `10s` overall.

**Example of current behavior:** A fast‑failing read of `/var/db/dhcpd_leases` causes `retryIPFromMAC` to continue forever without returning an error.

**Note:** No functional impact on production code, but it prevents local test runs from hanging and is much easier to debug.