### PR TITLE
Assorted fixes

### DIFF
--- a/cmd/vfkit/main.go
+++ b/cmd/vfkit/main.go
@@ -72,8 +72,8 @@ func newVMConfiguration(opts *cmdline.Options) (*config.VirtualMachine, error) {
 		return nil, err
 	}
 
-	log.Info(opts)
-	log.Infof("boot parameters: %+v", bootloader)
+	log.Debugf("parsed options: %+v", opts)
+	log.Debugf("boot parameters: %+v", bootloader)
 	log.Info()
 
 	vmConfig := config.NewVirtualMachine(

--- a/contrib/scripts/start-gvproxy.sh
+++ b/contrib/scripts/start-gvproxy.sh
@@ -23,7 +23,7 @@ set -exuo pipefail
 DISK_IMAGE="${1?Usage: $0 diskimage}"
 VM_NAME="$(basename ${DISK_IMAGE})"
 
-${GVPROXY} -mtu 1500 -ssh-port 2223 -listen-vfkit unixgram://$(pwd)/${VM_NAME}.sock  -log-file ${VM_NAME}.gvproxy.log --pid-file ${VM_NAME}.gvproxy.pid &
+${GVPROXY} --mtu 1500 --ssh-port 2223 --listen-vfkit unixgram://$(pwd)/${VM_NAME}.sock --log-file ${VM_NAME}.gvproxy.log --pid-file ${VM_NAME}.gvproxy.pid &
 
 TO_REMOVE="${VM_NAME}.sock ${VM_NAME}.gvproxy.pid ${VM_NAME}.overlay.img ${VM_NAME}.efistore.nvram"
 trap 'if [[ -f "${VM_NAME}.gvproxy.pid" ]]; then kill $(cat ${VM_NAME}.gvproxy.pid); fi; rm -f ${TO_REMOVE}' EXIT

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -15,7 +15,7 @@ Set the log-level for VFKit.  Supported values are `debug`, `info`, and `error`.
 
 - `--restful-uri`
 
-The URI (address) of the RESTful service.  The default is `tcp://localhost:8081`.  Valid schemes are
+The URI (address) of the RESTful service.  By default it’s disabled.  Valid schemes are
 `tcp`, `none`, or `unix`.  In the case of unix, the "host" portion would be a path to where the unix domain socket will be stored. A scheme of `none` disables the RESTful service.
 
 ### Virtual Machine Resources


### PR DESCRIPTION
One doc fix reported in https://github.com/containers/krunkit/pull/51#discussion_r2129155453
One consistency fix reported in https://github.com/crc-org/vfkit/pull/317#discussion_r2126936325
And silencing of 2 debug-looking logs.

## Summary by Sourcery

Silence nonessential logs, standardize script flag naming, and improve documentation clarity for the RESTful service default

Enhancements:
- Downgrade startup options and boot parameters logging from info to debug
- Unify pid-file flag style in start-gvproxy script for consistency

Documentation:
- Clarify in usage documentation that the RESTful service is disabled by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the RESTful service is disabled by default in the command line option documentation.

* **Style**
  * Updated script options to use long-form flags for improved clarity and consistency.

* **Refactor**
  * Adjusted certain log messages to appear only in debug mode instead of info mode, reducing log verbosity for standard usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->