### PR TITLE
Follow-up to #319

### DIFF
--- a/cmd/vfkit/main.go
+++ b/cmd/vfkit/main.go
@@ -74,7 +74,6 @@ func newVMConfiguration(opts *cmdline.Options) (*config.VirtualMachine, error) {
 
 	log.Debugf("parsed options: %+v", opts)
 	log.Debugf("boot parameters: %+v", bootloader)
-	log.Info()
 
 	vmConfig := config.NewVirtualMachine(
 		opts.Vcpus,

--- a/contrib/scripts/start-gvproxy.sh
+++ b/contrib/scripts/start-gvproxy.sh
@@ -23,7 +23,7 @@ set -exuo pipefail
 DISK_IMAGE="${1?Usage: $0 diskimage}"
 VM_NAME="$(basename ${DISK_IMAGE})"
 
-${GVPROXY} --mtu 1500 --ssh-port 2223 --listen-vfkit unixgram://$(pwd)/${VM_NAME}.sock --log-file ${VM_NAME}.gvproxy.log --pid-file ${VM_NAME}.gvproxy.pid &
+"${GVPROXY}" --mtu 1500 --ssh-port 2223 --listen-vfkit "unixgram://$(pwd)/${VM_NAME}.sock" --log-file "${VM_NAME}.gvproxy.log" --pid-file "${VM_NAME}.gvproxy.pid" &
 
 TO_REMOVE="${VM_NAME}.sock ${VM_NAME}.gvproxy.pid ${VM_NAME}.overlay.img ${VM_NAME}.efistore.nvram"
 trap 'if [[ -f "${VM_NAME}.gvproxy.pid" ]]; then kill $(cat ${VM_NAME}.gvproxy.pid); fi; rm -f ${TO_REMOVE}' EXIT

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -11,12 +11,12 @@ Device configuration is optional, but most VM will need a disk image and a netwo
 
 - `--log-level`
 
-Set the log-level for VFKit.  Supported values are `debug`, `info`, and `error`.
+Set the log-level for VFKit. Supported values are `debug`, `info`, and `error`.
 
 - `--restful-uri`
 
-The URI (address) of the RESTful service.  By default it’s disabled.  Valid schemes are
-`tcp`, `none`, or `unix`.  In the case of unix, the "host" portion would be a path to where the unix domain socket will be stored. A scheme of `none` disables the RESTful service.
+The URI (address) of the RESTful service. By default it’s disabled. Valid schemes are
+`tcp`, `none`, or `unix`. In the case of unix, the "host" portion would be a path to where the unix domain socket will be stored. A scheme of `none` disables the RESTful service.
 
 ### Virtual Machine Resources
 
@@ -66,7 +66,7 @@ Requirement: OPTIONAL
 
 The AArch64 kernel does not currently provide a decompressor and therefore
 requires decompression (gzip etc.) to be performed by the boot loader if a
-compressed Image target (e.g. Image.gz) is used.  For bootloaders that do not
+compressed Image target (e.g. Image.gz) is used. For bootloaders that do not
 implement this requirement, the uncompressed Image target is available instead.
 ```
 


### PR DESCRIPTION
There were several minor comments from coderabbit in #319
which were valuable. This commit addresses these.

## Summary by Sourcery

Apply minor style and cleanup changes across documentation, scripts, and code

Enhancements:
- Quote variables and URIs in start-gvproxy.sh to prevent word splitting
- Remove redundant log.Info() call in main.go

Documentation:
- Normalize spacing and line wrapping in usage documentation for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script reliability by correctly quoting command paths and arguments to handle spaces or special characters in file names.

* **Documentation**
  * Made minor formatting adjustments for consistency and readability in the usage guide.

* **Chores**
  * Removed an unnecessary informational log message to reduce log verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->