### PR TITLE
test: Update from f40 to f42

### DIFF
--- a/test/osprovider.go
+++ b/test/osprovider.go
@@ -45,12 +45,14 @@ func downloadPuipui(destDir string) ([]string, error) {
 }
 
 func downloadFedora(destDir string) (string, error) {
-	const fedoraVersion = "40"
+	const fedoraVersion = "42"
 	arch := kernelArch()
-	release := "1.14"
-	buildString := fmt.Sprintf("%s-%s-%s", arch, fedoraVersion, release)
+	release := "1.1"
 
-	var fedoraURL = fmt.Sprintf("https://download.fedoraproject.org/pub/fedora/linux/releases/%s/Cloud/%s/images/Fedora-Cloud-Base-AmazonEC2.%s.raw.xz", fedoraVersion, arch, buildString)
+	baseURL := fmt.Sprintf("https://download.fedoraproject.org/pub/fedora/linux/releases/%s/Cloud/%s/images", fedoraVersion, arch)
+	fileName := fmt.Sprintf("Fedora-Cloud-Base-AmazonEC2-%s-%s.%s.raw.xz", fedoraVersion, release, arch)
+	fedoraURL := fmt.Sprintf("%s/%s", baseURL, fileName)
+	log.Infof("downloading %s", fedoraURL)
 
 	// https://github.com/cavaliergopher/grab/issues/104
 	grab.DefaultClient.UserAgent = "vfkit"


### PR DESCRIPTION
The cloud-init test uses a fedora image. With the release of f42, f40
images have been deleted, which leads to CI failures.

Might be better to use
https://gitlab.com/fedora/websites-apps/fedora-websites/cms/fedoraproject.org/-/blob/main/content/release.yml?ref_type=heads
or some similar file to get the version/rc_version of the latest fedora release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Updated automated tests to use the latest Fedora Cloud image (version 42, release 1.1) to ensure reliable downloads.

- Chores
  - Enhanced test logging to record the constructed download URL for improved diagnostics.

- Note
  - No user-facing changes; product behavior and functionality remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->