### PR TITLE
feat: Support raw block devices

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -147,7 +147,10 @@ Various devices can be added to the virtual machines. They are all paravirtualiz
 
 #### Description
 
-The `--device virtio-blk` option adds a disk to the virtual machine. The disk is backed by an image file on the host machine. This file is a raw image file.
+The `--device virtio-blk` option adds a disk to the virtual machine. The disk can be backed either by a disk image file or by a host block device, depending on the type you choose:
+- type=image (default): uses a disk image file on the host machine (raw image file).
+- type=dev: attaches a host block device (for example, /dev/disk1 or /dev/disk1s1). Attaching a block device may require root privileges; use with care.
+
 See also [vz/CreateDiskImage](https://pkg.go.dev/github.com/Code-Hex/vz/v3#CreateDiskImage).
 
 #### Thin images
@@ -204,7 +207,8 @@ mkisofs -output seed.img -volid cidata -rock {user-data,meta-data}
 See https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html#example-creating-a-disk for further details about how to create a disk image
 
 #### Arguments
-- `path`: the absolute path to the disk image file.
+- `path`: the absolute path to the disk image file or block device.
+- `type`: the backing type. Use `image` (default) for a disk image file, or `dev` to attach a host block device (for example, /dev/disk1 or /dev/disk1s1). Attaching a block device may require root privileges; use with care.
 - `deviceId`: `/dev/disk/by-id/` identifier to use for this device.
 
 #### Example
@@ -212,6 +216,11 @@ See https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.htm
 This adds a virtio-blk device to the VM which will be backed by the raw image at `/Users/virtuser/vfkit.img`:
 ```
 --device virtio-blk,path=/Users/virtuser/vfkit.img
+```
+
+Attach a host block device instead (may require root privileges):
+```
+--device virtio-blk,path=/dev/disk2,type=dev
 ```
 
 To also provide the cloud-init configuration you can add an additional virtio-blk device backed by an image containing the cloud-init configuration files

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -285,29 +285,32 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 		newObjectFunc: func(t *testing.T) any {
 			blk, err := VirtioBlkNew("")
 			require.NoError(t, err)
+			blk.Type = DiskBackendImage
 			return blk
 		},
 
-		skipFields:   []string{"DevName", "URI"},
-		expectedJSON: `{"kind":"virtioblk","devName":"virtio-blk","imagePath":"ImagePath","readOnly":true,"deviceIdentifier":"DeviceIdentifier"}`,
+		skipFields:   []string{"DevName", "URI", "Type"},
+		expectedJSON: `{"kind":"virtioblk","devName":"virtio-blk","imagePath":"ImagePath","readOnly":true,"type":"image","deviceIdentifier":"DeviceIdentifier"}`,
 	},
 	"USBMassStorage": {
 		newObjectFunc: func(t *testing.T) any {
 			usb, err := USBMassStorageNew("")
 			require.NoError(t, err)
+			usb.Type = DiskBackendImage
 			return usb
 		},
-		skipFields:   []string{"DevName", "URI"},
-		expectedJSON: `{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"ImagePath","readOnly":true}`,
+		skipFields:   []string{"DevName", "URI", "Type"},
+		expectedJSON: `{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"ImagePath","readOnly":true,"type":"image"}`,
 	},
 	"NVMExpressController": {
 		newObjectFunc: func(t *testing.T) any {
 			nvme, err := NVMExpressControllerNew("")
 			require.NoError(t, err)
+			nvme.Type = DiskBackendImage
 			return nvme
 		},
-		skipFields:   []string{"DevName", "URI"},
-		expectedJSON: `{"kind":"nvme","devName":"nvme","imagePath":"ImagePath","readOnly":true}`,
+		skipFields:   []string{"DevName", "URI", "Type"},
+		expectedJSON: `{"kind":"nvme","devName":"nvme","imagePath":"ImagePath","readOnly":true,"type":"image"}`,
 	},
 	"LinuxBootloader": {
 		obj:          &LinuxBootloader{},

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -105,6 +105,49 @@ func TestVirtioDevices(t *testing.T) {
 			expectedCmdLine:  []string{"--device", fmt.Sprintf("virtio-blk,path=%s,deviceId=test", testImagePath)},
 			alternateCmdLine: []string{"--device", fmt.Sprintf("virtio-blk,deviceId=test,path=%s", testImagePath)},
 		},
+		"NewVirtioBlkWithType": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := getTestVirtioBlkDevice(testImagePath)
+				if err != nil {
+					return nil, err
+				}
+				dev.Type = DiskBackendBlockDevice
+				return dev, nil
+			},
+			expectedDev: &VirtioBlk{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "virtio-blk",
+					},
+					ImagePath: testImagePath,
+					Type:      DiskBackendBlockDevice,
+				},
+				DeviceIdentifier: "",
+			},
+			expectedCmdLine:  []string{"--device", fmt.Sprintf("virtio-blk,path=%s,type=dev", testImagePath)},
+			alternateCmdLine: []string{"--device", fmt.Sprintf("virtio-blk,type=dev,path=%s", testImagePath)},
+		},
+		"NewVirtioBlkWithDefaultType": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := getTestVirtioBlkDevice(testImagePath)
+				if err != nil {
+					return nil, err
+				}
+				dev.Type = DiskBackendDefault
+				return dev, nil
+			},
+			expectedDev: &VirtioBlk{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "virtio-blk",
+					},
+					ImagePath: testImagePath,
+					Type:      DiskBackendDefault,
+				},
+				DeviceIdentifier: "",
+			},
+			expectedCmdLine: []string{"--device", fmt.Sprintf("virtio-blk,path=%s", testImagePath)},
+		},
 		"NewNVMe": {
 			newDev: func() (VirtioDevice, error) { return NVMExpressControllerNew("/foo/bar") },
 			expectedDev: &NVMExpressController{
@@ -116,6 +159,27 @@ func TestVirtioDevices(t *testing.T) {
 				},
 			},
 			expectedCmdLine: []string{"--device", "nvme,path=/foo/bar"},
+		},
+		"NewNVMeWithType": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := NVMExpressControllerNew("/foo/bar")
+				if err != nil {
+					return nil, err
+				}
+				dev.Type = DiskBackendImage
+				return dev, nil
+			},
+			expectedDev: &NVMExpressController{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "nvme",
+					},
+					ImagePath: "/foo/bar",
+					Type:      DiskBackendImage,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "nvme,path=/foo/bar,type=image"},
+			alternateCmdLine: []string{"--device", "nvme,type=image,path=/foo/bar"},
 		},
 		"NewVirtioFs": {
 			newDev: func() (VirtioDevice, error) { return VirtioFsNew("/foo/bar", "") },


### PR DESCRIPTION
This PR adds support for raw block devices.

Since there is `NewDiskBlockDeviceStorageDeviceAttachment` API in vz, I was able to implement it with very little code.

However, I’m not sure if this is the best approach. Perhaps adding a new config type would be better? Or maybe we should warn users that they are performing a potentially dangerous operation? Suggestions are welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-disk backend selection via a new Type (image or dev) exposed in CLI, JSON, and runtime.

* **Bug Fixes**
  * Explicit validation and error reporting for disk image paths and host block devices; improved device-add logging and preserved image caching/sync behavior.

* **Documentation**
  * Usage docs updated with type parameter, examples for attaching host block devices, and cloud-init notes.

* **Tests**
  * Added tests for backend types and updated JSON stability expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->