### PR TITLE
cache sync options

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -210,14 +210,19 @@ See https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.htm
 - `path`: the absolute path to the disk image file or block device.
 - `type`: the backing type. Use `image` (default) for a disk image file, or `dev` to attach a host block device (for example, /dev/disk1 or /dev/disk1s1). Attaching a block device may require root privileges; use with care.
 - `deviceId`: `/dev/disk/by-id/` identifier to use for this device.
-- `cache`: disk image caching mode. Valid values:
+- `cache`: disk image caching mode (only for `type=image`, not supported for block devices). Valid values:
   - `automatic` (default): allows the virtualization framework to automatically determine whether to enable data caching
   - `cached`: enables data caching
   - `uncached`: disables data caching
-- `sync`: disk image synchronization mode. Valid values:
-  - `full`: synchronizes data to the permanent storage holding the disk image
-  - `fsync` (default): synchronizes data to the drive using the system's best-effort synchronization mode
-  - `none`: disables data synchronization with the permanent storage
+- `sync`: synchronization mode. Valid values differ by backing type:
+  - For disk images (`type=image`):
+    - `full`: synchronizes data to the permanent storage
+    - `fsync` (default): synchronizes data using the system's best-effort synchronization mode
+    - `none`: disables data synchronization
+  - For block devices (`type=dev`):
+    - `full` (default): synchronizes data to the permanent storage
+    - `none`: disables data synchronization
+    - Note: `fsync` is not supported for block devices
 
 #### Example
 
@@ -229,6 +234,11 @@ This adds a virtio-blk device to the VM which will be backed by the raw image at
 Attach a host block device instead (may require root privileges):
 ```
 --device virtio-blk,path=/dev/disk2,type=dev
+```
+
+Block device with sync mode disabled for maximum performance:
+```
+--device virtio-blk,path=/dev/disk2,type=dev,sync=none
 ```
 
 For ephemeral VMs where data persistence is not critical (maximize performance):
@@ -259,15 +269,21 @@ If you prefer to use the automatic ISO creation
 The `--device nvme` option adds a NVMe device to the virtual machine. The disk is backed by an image file on the host machine. This file is a raw image file.
 
 #### Arguments
-- `path`: the absolute path to the disk image file.
-- `cache`: disk image caching mode. Valid values:
+- `path`: the absolute path to the disk image file or block device.
+- `type`: the backing type. Use `image` (default) for a disk image file, or `dev` to attach a host block device. Attaching a block device may require root privileges; use with care.
+- `cache`: disk image caching mode (only for `type=image`, not supported for block devices). Valid values:
   - `automatic` (default): allows the virtualization framework to automatically determine whether to enable data caching
   - `cached`: enables data caching
   - `uncached`: disables data caching
-- `sync`: disk image synchronization mode. Valid values:
-  - `full`: synchronizes data to the permanent storage holding the disk image
-  - `fsync` (default): synchronizes data to the drive using the system's best-effort synchronization mode
-  - `none`: disables data synchronization with the permanent storage
+- `sync`: synchronization mode. Valid values differ by backing type:
+  - For disk images (`type=image`):
+    - `full`: synchronizes data to the permanent storage
+    - `fsync` (default): synchronizes data using the system's best-effort synchronization mode
+    - `none`: disables data synchronization
+  - For block devices (`type=dev`):
+    - `full` (default): synchronizes data to the permanent storage
+    - `none`: disables data synchronization
+    - Note: `fsync` is not supported for block devices
 
 #### Example
 
@@ -294,16 +310,22 @@ For database or critical workloads:
 The `--device usb-mass-storage` option adds a USB mass storage device to the virtual machine. The disk is backed by an image file on the host machine. This file is a raw image file or an ISO image.
 
 #### Arguments
-- `path`: the absolute path to the disk image file.
+- `path`: the absolute path to the disk image file or block device.
+- `type`: the backing type. Use `image` (default) for a disk image file, or `dev` to attach a host block device. Attaching a block device may require root privileges; use with care.
 - `readonly`: if specified the device will be read only.
-- `cache`: disk image caching mode. Valid values:
+- `cache`: disk image caching mode (only for `type=image`, not supported for block devices). Valid values:
   - `automatic` (default): allows the virtualization framework to automatically determine whether to enable data caching
   - `cached`: enables data caching
   - `uncached`: disables data caching
-- `sync`: disk image synchronization mode. Valid values:
-  - `full`: synchronizes data to the permanent storage holding the disk image
-  - `fsync` (default): synchronizes data to the drive using the system's best-effort synchronization mode
-  - `none`: disables data synchronization with the permanent storage
+- `sync`: synchronization mode. Valid values differ by backing type:
+  - For disk images (`type=image`):
+    - `full`: synchronizes data to the permanent storage
+    - `fsync` (default): synchronizes data using the system's best-effort synchronization mode
+    - `none`: disables data synchronization
+  - For block devices (`type=dev`):
+    - `full` (default): synchronizes data to the permanent storage
+    - `none`: disables data synchronization
+    - Note: `fsync` is not supported for block devices
 
 #### Example
 
@@ -320,6 +342,11 @@ For a read-only device with caching enabled:
 For a writable device with full data safety:
 ```
 --device usb-mass-storage,path=/Users/virtuser/data.img,cache=uncached,sync=full
+```
+
+When using a block device, you can specify the sync mode (cache is not supported):
+```
+--device usb-mass-storage,path=/dev/disk2,type=dev,sync=none
 ```
 
 ### Network Block Device

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -210,6 +210,14 @@ See https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.htm
 - `path`: the absolute path to the disk image file or block device.
 - `type`: the backing type. Use `image` (default) for a disk image file, or `dev` to attach a host block device (for example, /dev/disk1 or /dev/disk1s1). Attaching a block device may require root privileges; use with care.
 - `deviceId`: `/dev/disk/by-id/` identifier to use for this device.
+- `cache`: disk image caching mode. Valid values:
+  - `automatic` (default): allows the virtualization framework to automatically determine whether to enable data caching
+  - `cached`: enables data caching
+  - `uncached`: disables data caching
+- `sync`: disk image synchronization mode. Valid values:
+  - `full`: synchronizes data to the permanent storage holding the disk image
+  - `fsync` (default): synchronizes data to the drive using the system's best-effort synchronization mode
+  - `none`: disables data synchronization with the permanent storage
 
 #### Example
 
@@ -223,12 +231,22 @@ Attach a host block device instead (may require root privileges):
 --device virtio-blk,path=/dev/disk2,type=dev
 ```
 
+For ephemeral VMs where data persistence is not critical (maximize performance):
+```
+--device virtio-blk,path=/Users/virtuser/vfkit.img,cache=cached,sync=none
+```
+
+For database or critical workloads (maximize data safety):
+```
+--device virtio-blk,path=/Users/virtuser/vfkit.img,cache=uncached,sync=full
+```
+
 To also provide the cloud-init configuration you can add an additional virtio-blk device backed by an image containing the cloud-init configuration files
 ```
 --device virtio-blk,path=/Users/virtuser/cloudinit.img
 ```
 
-If you prefer to use the automatic ISO creation 
+If you prefer to use the automatic ISO creation
 ```
 --cloud-init /Users/virtuser/user-data,/Users/virtuser/meta-data
 ```

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -260,12 +260,30 @@ The `--device nvme` option adds a NVMe device to the virtual machine. The disk i
 
 #### Arguments
 - `path`: the absolute path to the disk image file.
+- `cache`: disk image caching mode. Valid values:
+  - `automatic` (default): allows the virtualization framework to automatically determine whether to enable data caching
+  - `cached`: enables data caching
+  - `uncached`: disables data caching
+- `sync`: disk image synchronization mode. Valid values:
+  - `full`: synchronizes data to the permanent storage holding the disk image
+  - `fsync` (default): synchronizes data to the drive using the system's best-effort synchronization mode
+  - `none`: disables data synchronization with the permanent storage
 
 #### Example
 
 This adds a NVMe device to the VM which will be backed by the disk image at `/Users/virtuser/image.img`:
 ```
 --device nvme,path=/Users/virtuser/image.img
+```
+
+For high-performance ephemeral storage:
+```
+--device nvme,path=/Users/virtuser/image.img,cache=cached,sync=none
+```
+
+For database or critical workloads:
+```
+--device nvme,path=/Users/virtuser/image.img,cache=uncached,sync=full
 ```
 
 
@@ -278,12 +296,30 @@ The `--device usb-mass-storage` option adds a USB mass storage device to the vir
 #### Arguments
 - `path`: the absolute path to the disk image file.
 - `readonly`: if specified the device will be read only.
+- `cache`: disk image caching mode. Valid values:
+  - `automatic` (default): allows the virtualization framework to automatically determine whether to enable data caching
+  - `cached`: enables data caching
+  - `uncached`: disables data caching
+- `sync`: disk image synchronization mode. Valid values:
+  - `full`: synchronizes data to the permanent storage holding the disk image
+  - `fsync` (default): synchronizes data to the drive using the system's best-effort synchronization mode
+  - `none`: disables data synchronization with the permanent storage
 
 #### Example
 
 This adds a read only USB mass storage device to the VM which will be backed by the ISO image at `/Users/virtuser/distro.iso`:
 ```
 --device usb-mass-storage,path=/Users/virtuser/distro.iso,readonly
+```
+
+For a read-only device with caching enabled:
+```
+--device usb-mass-storage,path=/Users/virtuser/distro.iso,readonly,cache=cached
+```
+
+For a writable device with full data safety:
+```
+--device usb-mass-storage,path=/Users/virtuser/data.img,cache=uncached,sync=full
 ```
 
 ### Network Block Device

--- a/pkg/config/json_test.go
+++ b/pkg/config/json_test.go
@@ -281,7 +281,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 			return blk
 		},
 
-		skipFields:   []string{"DevName", "URI", "Type"},
+		skipFields:   []string{"DevName", "URI", "Type", "CachingMode", "SynchronizationMode"},
 		expectedJSON: `{"kind":"virtioblk","devName":"virtio-blk","imagePath":"ImagePath","readOnly":true,"type":"image","deviceIdentifier":"DeviceIdentifier"}`,
 	},
 	"USBMassStorage": {
@@ -291,7 +291,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 			usb.Type = DiskBackendImage
 			return usb
 		},
-		skipFields:   []string{"DevName", "URI", "Type"},
+		skipFields:   []string{"DevName", "URI", "Type", "CachingMode", "SynchronizationMode"},
 		expectedJSON: `{"kind":"usbmassstorage","devName":"usb-mass-storage","imagePath":"ImagePath","readOnly":true,"type":"image"}`,
 	},
 	"NVMExpressController": {
@@ -301,7 +301,7 @@ var jsonStabilityTests = map[string]jsonStabilityTest{
 			nvme.Type = DiskBackendImage
 			return nvme
 		},
-		skipFields:   []string{"DevName", "URI", "Type"},
+		skipFields:   []string{"DevName", "URI", "Type", "CachingMode", "SynchronizationMode"},
 		expectedJSON: `{"kind":"nvme","devName":"nvme","imagePath":"ImagePath","readOnly":true,"type":"image"}`,
 	},
 	"LinuxBootloader": {

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -650,7 +650,12 @@ func (dev *VirtioBlk) validate() error {
 		return err
 	}
 
-	// Then check for qcow2 images
+	// Skip qcow2 check for block devices (they can't be qcow2 format)
+	if dev.Type == DiskBackendBlockDevice {
+		return nil
+	}
+
+	// Then check for qcow2 images (only for disk image files)
 	imgPath := dev.ImagePath
 	file, err := os.Open(imgPath)
 	if err != nil {
@@ -1056,13 +1061,15 @@ func (config *DiskStorageConfig) FromOptions(options []option) error {
 }
 
 func (config *DiskStorageConfig) validate() error {
-	// Cache and sync modes are only supported for disk images, not block devices
+	// Validate options for block devices (type=dev)
 	if config.Type == DiskBackendBlockDevice {
+		// Cache mode is not supported for block devices
 		if config.CachingMode != "" {
 			return fmt.Errorf("cache mode is not supported for block devices (type=dev)")
 		}
-		if config.SynchronizationMode != "" {
-			return fmt.Errorf("sync mode is not supported for block devices (type=dev)")
+		// Block devices only support 'full' and 'none' sync modes, not 'fsync'
+		if config.SynchronizationMode == SyncModeFsync {
+			return fmt.Errorf("sync mode 'fsync' is not supported for block devices (type=dev), use 'full' or 'none'")
 		}
 	}
 	return nil

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -930,10 +930,57 @@ func (typ DiskBackendType) IsValid() bool {
 	}
 }
 
+// DiskImageCachingMode describes the disk image caching mode.
+// See: https://developer.apple.com/documentation/virtualization/vzdiskimagecachingmode
+type DiskImageCachingMode string
+
+const (
+	// CachingModeAutomatic allows the virtualization framework to automatically
+	// determine whether to enable data caching.
+	CachingModeAutomatic DiskImageCachingMode = "automatic"
+	// CachingModeCached enables data caching.
+	CachingModeCached DiskImageCachingMode = "cached"
+	// CachingModeUncached disables data caching.
+	CachingModeUncached DiskImageCachingMode = "uncached"
+)
+
+func (mode DiskImageCachingMode) IsValid() bool {
+	switch mode {
+	case CachingModeAutomatic, CachingModeCached, CachingModeUncached, "":
+		return true
+	default:
+		return false
+	}
+}
+
+// DiskImageSynchronizationMode describes the disk image synchronization mode.
+// See: https://developer.apple.com/documentation/virtualization/vzdiskimagesynchronizationmode
+type DiskImageSynchronizationMode string
+
+const (
+	// SyncModeFull synchronizes data to the permanent storage holding the disk image.
+	SyncModeFull DiskImageSynchronizationMode = "full"
+	// SyncModeFsync synchronizes data to the drive using the system's best-effort synchronization mode.
+	SyncModeFsync DiskImageSynchronizationMode = "fsync"
+	// SyncModeNone disables data synchronization with the permanent storage.
+	SyncModeNone DiskImageSynchronizationMode = "none"
+)
+
+func (mode DiskImageSynchronizationMode) IsValid() bool {
+	switch mode {
+	case SyncModeFull, SyncModeFsync, SyncModeNone, "":
+		return true
+	default:
+		return false
+	}
+}
+
 type DiskStorageConfig struct {
 	StorageConfig
-	ImagePath string          `json:"imagePath,omitempty"`
-	Type      DiskBackendType `json:"type,omitempty"`
+	ImagePath           string                       `json:"imagePath,omitempty"`
+	Type                DiskBackendType              `json:"type,omitempty"`
+	CachingMode         DiskImageCachingMode         `json:"cachingMode,omitempty"`
+	SynchronizationMode DiskImageSynchronizationMode `json:"synchronizationMode,omitempty"`
 }
 
 type NetworkBlockStorageConfig struct {
@@ -955,6 +1002,15 @@ func (config *DiskStorageConfig) ToCmdLine() ([]string, error) {
 	if config.ReadOnly {
 		value += ",readonly"
 	}
+
+	if config.CachingMode != "" {
+		value += fmt.Sprintf(",cache=%s", string(config.CachingMode))
+	}
+
+	if config.SynchronizationMode != "" {
+		value += fmt.Sprintf(",sync=%s", string(config.SynchronizationMode))
+	}
+
 	return []string{"--device", value}, nil
 }
 
@@ -974,6 +1030,18 @@ func (config *DiskStorageConfig) FromOptions(options []option) error {
 				return fmt.Errorf("unexpected value for virtio-blk 'readonly' option: %s", option.value)
 			}
 			config.ReadOnly = true
+		case "cache":
+			mode := DiskImageCachingMode(option.value)
+			if !mode.IsValid() {
+				return fmt.Errorf("unexpected value for disk 'cache' option: %s (valid values: automatic, cached, uncached)", option.value)
+			}
+			config.CachingMode = mode
+		case "sync":
+			mode := DiskImageSynchronizationMode(option.value)
+			if !mode.IsValid() {
+				return fmt.Errorf("unexpected value for disk 'sync' option: %s (valid values: full, fsync, none)", option.value)
+			}
+			config.SynchronizationMode = mode
 		default:
 			return fmt.Errorf("unknown option for %s devices: %s", config.DevName, option.key)
 		}

--- a/pkg/config/virtio.go
+++ b/pkg/config/virtio.go
@@ -645,6 +645,12 @@ func (dev *VirtioBlk) ToCmdLine() ([]string, error) {
 }
 
 func (dev *VirtioBlk) validate() error {
+	// First validate the disk storage config (cache/sync mode constraints)
+	if err := dev.DiskStorageConfig.validate(); err != nil {
+		return err
+	}
+
+	// Then check for qcow2 images
 	imgPath := dev.ImagePath
 	file, err := os.Open(imgPath)
 	if err != nil {
@@ -1044,6 +1050,19 @@ func (config *DiskStorageConfig) FromOptions(options []option) error {
 			config.SynchronizationMode = mode
 		default:
 			return fmt.Errorf("unknown option for %s devices: %s", config.DevName, option.key)
+		}
+	}
+	return config.validate()
+}
+
+func (config *DiskStorageConfig) validate() error {
+	// Cache and sync modes are only supported for disk images, not block devices
+	if config.Type == DiskBackendBlockDevice {
+		if config.CachingMode != "" {
+			return fmt.Errorf("cache mode is not supported for block devices (type=dev)")
+		}
+		if config.SynchronizationMode != "" {
+			return fmt.Errorf("sync mode is not supported for block devices (type=dev)")
 		}
 	}
 	return nil

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -261,6 +261,71 @@ func TestVirtioDevices(t *testing.T) {
 			expectedCmdLine:  []string{"--device", "nvme,path=/foo/bar,type=image"},
 			alternateCmdLine: []string{"--device", "nvme,type=image,path=/foo/bar"},
 		},
+		"NewNVMeWithCacheMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := NVMExpressControllerNew("/foo/bar")
+				if err != nil {
+					return nil, err
+				}
+				dev.CachingMode = CachingModeUncached
+				return dev, nil
+			},
+			expectedDev: &NVMExpressController{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "nvme",
+					},
+					ImagePath:   "/foo/bar",
+					CachingMode: CachingModeUncached,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "nvme,path=/foo/bar,cache=uncached"},
+			alternateCmdLine: []string{"--device", "nvme,cache=uncached,path=/foo/bar"},
+		},
+		"NewNVMeWithSyncMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := NVMExpressControllerNew("/foo/bar")
+				if err != nil {
+					return nil, err
+				}
+				dev.SynchronizationMode = SyncModeFull
+				return dev, nil
+			},
+			expectedDev: &NVMExpressController{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "nvme",
+					},
+					ImagePath:           "/foo/bar",
+					SynchronizationMode: SyncModeFull,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "nvme,path=/foo/bar,sync=full"},
+			alternateCmdLine: []string{"--device", "nvme,sync=full,path=/foo/bar"},
+		},
+		"NewNVMeWithCacheAndSyncMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := NVMExpressControllerNew("/foo/bar")
+				if err != nil {
+					return nil, err
+				}
+				dev.CachingMode = CachingModeUncached
+				dev.SynchronizationMode = SyncModeFull
+				return dev, nil
+			},
+			expectedDev: &NVMExpressController{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "nvme",
+					},
+					ImagePath:           "/foo/bar",
+					CachingMode:         CachingModeUncached,
+					SynchronizationMode: SyncModeFull,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "nvme,path=/foo/bar,cache=uncached,sync=full"},
+			alternateCmdLine: []string{"--device", "nvme,cache=uncached,sync=full,path=/foo/bar"},
+		},
 		"NewVirtioFs": {
 			newDev: func() (VirtioDevice, error) { return VirtioFsNew("/foo/bar", "") },
 			expectedDev: &VirtioFs{
@@ -396,6 +461,71 @@ func TestVirtioDevices(t *testing.T) {
 				},
 			},
 			expectedCmdLine: []string{"--device", "usb-mass-storage,path=/foo/bar,readonly"},
+		},
+		"NewUSBMassStorageWithCacheMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := USBMassStorageNew("/foo/bar")
+				if err != nil {
+					return nil, err
+				}
+				dev.CachingMode = CachingModeCached
+				return dev, nil
+			},
+			expectedDev: &USBMassStorage{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "usb-mass-storage",
+					},
+					ImagePath:   "/foo/bar",
+					CachingMode: CachingModeCached,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "usb-mass-storage,path=/foo/bar,cache=cached"},
+			alternateCmdLine: []string{"--device", "usb-mass-storage,cache=cached,path=/foo/bar"},
+		},
+		"NewUSBMassStorageWithSyncMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := USBMassStorageNew("/foo/bar")
+				if err != nil {
+					return nil, err
+				}
+				dev.SynchronizationMode = SyncModeNone
+				return dev, nil
+			},
+			expectedDev: &USBMassStorage{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "usb-mass-storage",
+					},
+					ImagePath:           "/foo/bar",
+					SynchronizationMode: SyncModeNone,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "usb-mass-storage,path=/foo/bar,sync=none"},
+			alternateCmdLine: []string{"--device", "usb-mass-storage,sync=none,path=/foo/bar"},
+		},
+		"NewUSBMassStorageWithCacheAndSyncMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := USBMassStorageNew("/foo/bar")
+				if err != nil {
+					return nil, err
+				}
+				dev.CachingMode = CachingModeUncached
+				dev.SynchronizationMode = SyncModeFull
+				return dev, nil
+			},
+			expectedDev: &USBMassStorage{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "usb-mass-storage",
+					},
+					ImagePath:           "/foo/bar",
+					CachingMode:         CachingModeUncached,
+					SynchronizationMode: SyncModeFull,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "usb-mass-storage,path=/foo/bar,cache=uncached,sync=full"},
+			alternateCmdLine: []string{"--device", "usb-mass-storage,cache=uncached,sync=full,path=/foo/bar"},
 		},
 		"NewVirtioInputWithPointingDevice": {
 			newDev: func() (VirtioDevice, error) { return VirtioInputNew("pointing") },

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -148,6 +148,86 @@ func TestVirtioDevices(t *testing.T) {
 			},
 			expectedCmdLine: []string{"--device", fmt.Sprintf("virtio-blk,path=%s", testImagePath)},
 		},
+		"NewVirtioBlkWithCacheMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := getTestVirtioBlkDevice(testImagePath)
+				if err != nil {
+					return nil, err
+				}
+				dev.CachingMode = CachingModeUncached
+				return dev, nil
+			},
+			expectedDev: &VirtioBlk{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "virtio-blk",
+					},
+					ImagePath:   testImagePath,
+					CachingMode: CachingModeUncached,
+				},
+				DeviceIdentifier: "",
+			},
+			expectedCmdLine:  []string{"--device", fmt.Sprintf("virtio-blk,path=%s,cache=uncached", testImagePath)},
+			alternateCmdLine: []string{"--device", fmt.Sprintf("virtio-blk,cache=uncached,path=%s", testImagePath)},
+		},
+		"NewVirtioBlkWithSyncMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := getTestVirtioBlkDevice(testImagePath)
+				if err != nil {
+					return nil, err
+				}
+				dev.SynchronizationMode = SyncModeFull
+				return dev, nil
+			},
+			expectedDev: &VirtioBlk{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "virtio-blk",
+					},
+					ImagePath:           testImagePath,
+					SynchronizationMode: SyncModeFull,
+				},
+				DeviceIdentifier: "",
+			},
+			expectedCmdLine:  []string{"--device", fmt.Sprintf("virtio-blk,path=%s,sync=full", testImagePath)},
+			alternateCmdLine: []string{"--device", fmt.Sprintf("virtio-blk,sync=full,path=%s", testImagePath)},
+		},
+		"NewVirtioBlkWithCacheAndSyncMode": {
+			newDev: func() (VirtioDevice, error) {
+				dev, err := getTestVirtioBlkDevice(testImagePath)
+				if err != nil {
+					return nil, err
+				}
+				dev.CachingMode = CachingModeUncached
+				dev.SynchronizationMode = SyncModeFull
+				return dev, nil
+			},
+			expectedDev: &VirtioBlk{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "virtio-blk",
+					},
+					ImagePath:           testImagePath,
+					CachingMode:         CachingModeUncached,
+					SynchronizationMode: SyncModeFull,
+				},
+				DeviceIdentifier: "",
+			},
+			expectedCmdLine:  []string{"--device", fmt.Sprintf("virtio-blk,path=%s,cache=uncached,sync=full", testImagePath)},
+			alternateCmdLine: []string{"--device", fmt.Sprintf("virtio-blk,cache=uncached,sync=full,path=%s", testImagePath)},
+		},
+		"NewVirtioBlkWithInvalidCacheMode": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine(fmt.Sprintf("virtio-blk,path=%s,cache=invalid", testImagePath))
+			},
+			errorMsg: "unexpected value for disk 'cache' option: invalid (valid values: automatic, cached, uncached)",
+		},
+		"NewVirtioBlkWithInvalidSyncMode": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine(fmt.Sprintf("virtio-blk,path=%s,sync=invalid", testImagePath))
+			},
+			errorMsg: "unexpected value for disk 'sync' option: invalid (valid values: full, fsync, none)",
+		},
 		"NewNVMe": {
 			newDev: func() (VirtioDevice, error) { return NVMExpressControllerNew("/foo/bar") },
 			expectedDev: &NVMExpressController{

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -228,6 +228,24 @@ func TestVirtioDevices(t *testing.T) {
 			},
 			errorMsg: "unexpected value for disk 'sync' option: invalid (valid values: full, fsync, none)",
 		},
+		"NewVirtioBlkBlockDeviceWithCache": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("virtio-blk,path=/dev/disk1,type=dev,cache=cached")
+			},
+			errorMsg: "cache mode is not supported for block devices (type=dev)",
+		},
+		"NewVirtioBlkBlockDeviceWithSync": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("virtio-blk,path=/dev/disk1,type=dev,sync=full")
+			},
+			errorMsg: "sync mode is not supported for block devices (type=dev)",
+		},
+		"NewVirtioBlkBlockDeviceWithCacheAndSync": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("virtio-blk,path=/dev/disk1,type=dev,cache=cached,sync=full")
+			},
+			errorMsg: "cache mode is not supported for block devices (type=dev)",
+		},
 		"NewNVMe": {
 			newDev: func() (VirtioDevice, error) { return NVMExpressControllerNew("/foo/bar") },
 			expectedDev: &NVMExpressController{
@@ -325,6 +343,18 @@ func TestVirtioDevices(t *testing.T) {
 			},
 			expectedCmdLine:  []string{"--device", "nvme,path=/foo/bar,cache=uncached,sync=full"},
 			alternateCmdLine: []string{"--device", "nvme,cache=uncached,sync=full,path=/foo/bar"},
+		},
+		"NewNVMeBlockDeviceWithCache": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("nvme,path=/dev/disk1,type=dev,cache=cached")
+			},
+			errorMsg: "cache mode is not supported for block devices (type=dev)",
+		},
+		"NewNVMeBlockDeviceWithSync": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("nvme,path=/dev/disk1,type=dev,sync=full")
+			},
+			errorMsg: "sync mode is not supported for block devices (type=dev)",
 		},
 		"NewVirtioFs": {
 			newDev: func() (VirtioDevice, error) { return VirtioFsNew("/foo/bar", "") },
@@ -526,6 +556,18 @@ func TestVirtioDevices(t *testing.T) {
 			},
 			expectedCmdLine:  []string{"--device", "usb-mass-storage,path=/foo/bar,cache=uncached,sync=full"},
 			alternateCmdLine: []string{"--device", "usb-mass-storage,cache=uncached,sync=full,path=/foo/bar"},
+		},
+		"NewUSBMassStorageBlockDeviceWithCache": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("usb-mass-storage,path=/dev/disk1,type=dev,cache=cached")
+			},
+			errorMsg: "cache mode is not supported for block devices (type=dev)",
+		},
+		"NewUSBMassStorageBlockDeviceWithSync": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("usb-mass-storage,path=/dev/disk1,type=dev,sync=full")
+			},
+			errorMsg: "sync mode is not supported for block devices (type=dev)",
 		},
 		"NewVirtioInputWithPointingDevice": {
 			newDev: func() (VirtioDevice, error) { return VirtioInputNew("pointing") },

--- a/pkg/config/virtio_test.go
+++ b/pkg/config/virtio_test.go
@@ -234,11 +234,45 @@ func TestVirtioDevices(t *testing.T) {
 			},
 			errorMsg: "cache mode is not supported for block devices (type=dev)",
 		},
-		"NewVirtioBlkBlockDeviceWithSync": {
+		"NewVirtioBlkBlockDeviceWithSyncFull": {
 			newDev: func() (VirtioDevice, error) {
 				return deviceFromCmdLine("virtio-blk,path=/dev/disk1,type=dev,sync=full")
 			},
-			errorMsg: "sync mode is not supported for block devices (type=dev)",
+			expectedDev: &VirtioBlk{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "virtio-blk",
+					},
+					ImagePath:           "/dev/disk1",
+					Type:                DiskBackendBlockDevice,
+					SynchronizationMode: SyncModeFull,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "virtio-blk,path=/dev/disk1,type=dev,sync=full"},
+			alternateCmdLine: []string{"--device", "virtio-blk,type=dev,sync=full,path=/dev/disk1"},
+		},
+		"NewVirtioBlkBlockDeviceWithSyncNone": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("virtio-blk,path=/dev/disk1,type=dev,sync=none")
+			},
+			expectedDev: &VirtioBlk{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "virtio-blk",
+					},
+					ImagePath:           "/dev/disk1",
+					Type:                DiskBackendBlockDevice,
+					SynchronizationMode: SyncModeNone,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "virtio-blk,path=/dev/disk1,type=dev,sync=none"},
+			alternateCmdLine: []string{"--device", "virtio-blk,type=dev,sync=none,path=/dev/disk1"},
+		},
+		"NewVirtioBlkBlockDeviceWithSyncFsyncError": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("virtio-blk,path=/dev/disk1,type=dev,sync=fsync")
+			},
+			errorMsg: "sync mode 'fsync' is not supported for block devices (type=dev), use 'full' or 'none'",
 		},
 		"NewVirtioBlkBlockDeviceWithCacheAndSync": {
 			newDev: func() (VirtioDevice, error) {
@@ -350,11 +384,45 @@ func TestVirtioDevices(t *testing.T) {
 			},
 			errorMsg: "cache mode is not supported for block devices (type=dev)",
 		},
-		"NewNVMeBlockDeviceWithSync": {
+		"NewNVMeBlockDeviceWithSyncFull": {
 			newDev: func() (VirtioDevice, error) {
 				return deviceFromCmdLine("nvme,path=/dev/disk1,type=dev,sync=full")
 			},
-			errorMsg: "sync mode is not supported for block devices (type=dev)",
+			expectedDev: &NVMExpressController{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "nvme",
+					},
+					ImagePath:           "/dev/disk1",
+					Type:                DiskBackendBlockDevice,
+					SynchronizationMode: SyncModeFull,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "nvme,path=/dev/disk1,type=dev,sync=full"},
+			alternateCmdLine: []string{"--device", "nvme,type=dev,sync=full,path=/dev/disk1"},
+		},
+		"NewNVMeBlockDeviceWithSyncNone": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("nvme,path=/dev/disk1,type=dev,sync=none")
+			},
+			expectedDev: &NVMExpressController{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "nvme",
+					},
+					ImagePath:           "/dev/disk1",
+					Type:                DiskBackendBlockDevice,
+					SynchronizationMode: SyncModeNone,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "nvme,path=/dev/disk1,type=dev,sync=none"},
+			alternateCmdLine: []string{"--device", "nvme,type=dev,sync=none,path=/dev/disk1"},
+		},
+		"NewNVMeBlockDeviceWithSyncFsyncError": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("nvme,path=/dev/disk1,type=dev,sync=fsync")
+			},
+			errorMsg: "sync mode 'fsync' is not supported for block devices (type=dev), use 'full' or 'none'",
 		},
 		"NewVirtioFs": {
 			newDev: func() (VirtioDevice, error) { return VirtioFsNew("/foo/bar", "") },
@@ -563,11 +631,45 @@ func TestVirtioDevices(t *testing.T) {
 			},
 			errorMsg: "cache mode is not supported for block devices (type=dev)",
 		},
-		"NewUSBMassStorageBlockDeviceWithSync": {
+		"NewUSBMassStorageBlockDeviceWithSyncFull": {
 			newDev: func() (VirtioDevice, error) {
 				return deviceFromCmdLine("usb-mass-storage,path=/dev/disk1,type=dev,sync=full")
 			},
-			errorMsg: "sync mode is not supported for block devices (type=dev)",
+			expectedDev: &USBMassStorage{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "usb-mass-storage",
+					},
+					ImagePath:           "/dev/disk1",
+					Type:                DiskBackendBlockDevice,
+					SynchronizationMode: SyncModeFull,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "usb-mass-storage,path=/dev/disk1,type=dev,sync=full"},
+			alternateCmdLine: []string{"--device", "usb-mass-storage,type=dev,sync=full,path=/dev/disk1"},
+		},
+		"NewUSBMassStorageBlockDeviceWithSyncNone": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("usb-mass-storage,path=/dev/disk1,type=dev,sync=none")
+			},
+			expectedDev: &USBMassStorage{
+				DiskStorageConfig: DiskStorageConfig{
+					StorageConfig: StorageConfig{
+						DevName: "usb-mass-storage",
+					},
+					ImagePath:           "/dev/disk1",
+					Type:                DiskBackendBlockDevice,
+					SynchronizationMode: SyncModeNone,
+				},
+			},
+			expectedCmdLine:  []string{"--device", "usb-mass-storage,path=/dev/disk1,type=dev,sync=none"},
+			alternateCmdLine: []string{"--device", "usb-mass-storage,type=dev,sync=none,path=/dev/disk1"},
+		},
+		"NewUSBMassStorageBlockDeviceWithSyncFsyncError": {
+			newDev: func() (VirtioDevice, error) {
+				return deviceFromCmdLine("usb-mass-storage,path=/dev/disk1,type=dev,sync=fsync")
+			},
+			errorMsg: "sync mode 'fsync' is not supported for block devices (type=dev), use 'full' or 'none'",
 		},
 		"NewVirtioInputWithPointingDevice": {
 			newDev: func() (VirtioDevice, error) { return VirtioInputNew("pointing") },

--- a/pkg/vf/virtio.go
+++ b/pkg/vf/virtio.go
@@ -495,14 +495,43 @@ func AddToVirtualMachineConfig(vmConfig *VirtualMachineConfiguration, dev config
 	}
 }
 
+func toVzCachingMode(mode config.DiskImageCachingMode) vz.DiskImageCachingMode {
+	switch mode {
+	case config.CachingModeAutomatic:
+		return vz.DiskImageCachingModeAutomatic
+	case config.CachingModeCached:
+		return vz.DiskImageCachingModeCached
+	case config.CachingModeUncached:
+		return vz.DiskImageCachingModeUncached
+	default:
+		// Default to cached for backward compatibility
+		return vz.DiskImageCachingModeCached
+	}
+}
+
+func toVzSyncMode(mode config.DiskImageSynchronizationMode) vz.DiskImageSynchronizationMode {
+	switch mode {
+	case config.SyncModeFull:
+		return vz.DiskImageSynchronizationModeFull
+	case config.SyncModeFsync:
+		return vz.DiskImageSynchronizationModeFsync
+	case config.SyncModeNone:
+		return vz.DiskImageSynchronizationModeNone
+	default:
+		// Default to fsync for backward compatibility
+		return vz.DiskImageSynchronizationModeFsync
+	}
+}
+
 func (conf *DiskStorageConfig) toVz() (vz.StorageDeviceAttachment, error) {
 	switch conf.Type {
 	case config.DiskBackendImage, config.DiskBackendDefault:
 		if conf.ImagePath == "" {
 			return nil, fmt.Errorf("missing mandatory 'path' option for %s device", conf.DevName)
 		}
-		syncMode := vz.DiskImageSynchronizationModeFsync
-		caching := vz.DiskImageCachingModeCached
+		// Use user-specified modes if provided, otherwise use defaults for backward compatibility
+		syncMode := toVzSyncMode(conf.SynchronizationMode)
+		caching := toVzCachingMode(conf.CachingMode)
 		return vz.NewDiskImageStorageDeviceAttachmentWithCacheAndSync(conf.ImagePath, conf.ReadOnly, caching, syncMode)
 	case config.DiskBackendBlockDevice:
 		var stat unix.Stat_t

--- a/pkg/vf/virtio.go
+++ b/pkg/vf/virtio.go
@@ -523,6 +523,19 @@ func toVzSyncMode(mode config.DiskImageSynchronizationMode) vz.DiskImageSynchron
 	}
 }
 
+func toVzBlockDeviceSyncMode(mode config.DiskImageSynchronizationMode) vz.DiskSynchronizationMode {
+	switch mode {
+	case config.SyncModeFull:
+		return vz.DiskSynchronizationModeFull
+	case config.SyncModeNone:
+		return vz.DiskSynchronizationModeNone
+	default:
+		// Default to full for backward compatibility
+		// Note: fsync is not supported for block devices and should be caught by validation
+		return vz.DiskSynchronizationModeFull
+	}
+}
+
 func (conf *DiskStorageConfig) toVz() (vz.StorageDeviceAttachment, error) {
 	switch conf.Type {
 	case config.DiskBackendImage, config.DiskBackendDefault:
@@ -558,7 +571,8 @@ func (conf *DiskStorageConfig) toVz() (vz.StorageDeviceAttachment, error) {
 			return nil, fmt.Errorf("error opening file: %v", err)
 		}
 
-		syncMode := vz.DiskSynchronizationModeFull
+		// Use user-specified sync mode if provided, otherwise use full for backward compatibility
+		syncMode := toVzBlockDeviceSyncMode(conf.SynchronizationMode)
 		attachment, err := vz.NewDiskBlockDeviceStorageDeviceAttachment(f, conf.ReadOnly, syncMode)
 		if err != nil {
 			_ = f.Close()


### PR DESCRIPTION
This adds cache syncing options, both for file-backed virtio-blk 
instances, and block-device backed virtio-blk devices.

This was mostly authored by Claude

- **Add virtio-blk cache and sync mode configuration options**
- **Extend cache and sync mode options to NVMe and USB mass storage**
- **Add validation to prevent cache/sync options on block devices**
- **Add sync mode support for block devices**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `cache` and `sync` parameters for disk devices to control I/O caching and synchronization for image-backed and block-device-backed storage.

* **Documentation**
  * Expanded CLI docs and examples showing valid cache/sync combinations for image and block-device disks.

* **Validation**
  * Improved option validation: rejects `cache` for block-device-backed disks and rejects unsupported sync modes for block devices; accepts `sync=full`/`sync=none` where applicable.

* **Tests**
  * Added coverage for new cache/sync parsing, round-trip behavior, and invalid combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->