### PR TITLE
cloud-init: clean up orphaned temp ISOs on startup

### DIFF
--- a/cmd/vfkit/main.go
+++ b/cmd/vfkit/main.go
@@ -406,9 +406,9 @@ func createCloudInitISO(files map[string]io.Reader) (string, error) {
 		}
 	}
 
-	isoFile, err := os.CreateTemp("", "vfkit-cloudinit-")
+	isoFile, err := util.CreateCloudInitISOFile()
 	if err != nil {
-		return "", fmt.Errorf("unable to create temporary cloud-init ISO file: %w", err)
+		return "", err
 	}
 
 	defer func() {

--- a/cmd/vfkit/root.go
+++ b/cmd/vfkit/root.go
@@ -18,6 +18,9 @@ var rootCmd = &cobra.Command{
 	Long: `A hypervisor written in Go using Apple's Virtualization framework to run virtual machines.
                 Complete documentation is available at https://github.com/crc-org/vfkit`,
 	RunE: func(_ *cobra.Command, _ []string) error {
+		// if vfkit stop execution by itself, i.e. when VM stops by guest OS
+		// we need to call ExecuteExitHandlers to clean up
+		defer util.ExecuteExitHandlers()
 		if len(opts.LogLevel) > 0 {
 			ll, err := getLogLevel()
 			if err != nil {
@@ -25,13 +28,13 @@ var rootCmd = &cobra.Command{
 			}
 			logrus.SetLevel(ll)
 		}
+		if err := util.CleanupStaleCloudInitISO(); err != nil {
+			logrus.Warnf("failed to cleanup stale cloud-init ISO: %v", err)
+		}
 		vmConfig, err := newVMConfiguration(opts)
 		if err != nil {
 			return err
 		}
-		// if vfkit stop execution by itself, i.e. when VM stops by guest OS
-		// we need to call ExecuteExitHandlers to clean up
-		defer util.ExecuteExitHandlers()
 		return runVFKit(vmConfig, opts)
 	},
 	Version: cmdline.Version(),

--- a/pkg/util/credtemp.go
+++ b/pkg/util/credtemp.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/shirou/gopsutil/v4/process"
+	"github.com/sirupsen/logrus"
+)
+
+const cloudInitPrefix = "vfkit-cloudinit"
+
+var cloudInitTempDir = filepath.Join(os.TempDir(), cloudInitPrefix)
+
+func CreateCloudInitISOFile() (*os.File, error) {
+	if err := os.MkdirAll(cloudInitTempDir, 0700); err != nil {
+		return nil, fmt.Errorf("unable to create directory %s: %w", cloudInitTempDir, err)
+	}
+	pid := os.Getpid()
+	file, err := os.CreateTemp(cloudInitTempDir, fmt.Sprintf("%s-%d-*.iso", cloudInitPrefix, pid))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create cloud-init ISO temporary file: %w", err)
+	}
+	return file, nil
+}
+
+func CleanupStaleCloudInitISO() error {
+	entries, err := os.ReadDir(cloudInitTempDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unable to read directory %s: %w", cloudInitTempDir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filename := entry.Name()
+		var pid int32
+		if _, err := fmt.Sscanf(filename, cloudInitPrefix+"-%d-", &pid); err != nil {
+			continue
+		}
+		exists, err := process.PidExists(pid)
+		if err != nil {
+			continue
+		}
+		if exists {
+			continue
+		}
+		if err := os.Remove(filepath.Join(cloudInitTempDir, filename)); err != nil {
+			return fmt.Errorf("unable to remove file %s: %w", filepath.Join(cloudInitTempDir, filename), err)
+		}
+		logrus.Debugf("removed stale cloud-init ISO %s", filepath.Join(cloudInitTempDir, filename))
+	}
+	return nil
+}

--- a/pkg/util/exithandler.go
+++ b/pkg/util/exithandler.go
@@ -55,8 +55,8 @@ func setupExitSignalHandling(shutdownFunc func()) {
 // This function should be called when program finish work(i.e. when VM is turned off by guest OS)
 func ExecuteExitHandlers() {
 	exitRegistry.mutex.Lock()
+	defer exitRegistry.mutex.Unlock()
 	for _, handler := range exitRegistry.handlers {
 		handler()
 	}
-	exitRegistry.mutex.Unlock()
 }


### PR DESCRIPTION
Remove stale cloud-init ISO files left after abrupt termination. Use a dedicated temp directory with PID-tagged filenames so cleanup does not remove ISOs from other running vfkit instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevent stale temporary cloud-init ISO files from accumulating by cleaning up older ISOs tied to inactive PIDs during startup.
  * Improve shutdown reliability by ensuring exit-handler mutex locking is always released safely, even if a handler panics.

* **New Features**
  * Centralize temporary cloud-init ISO creation with a shared utility that uses a dedicated temp subdirectory and PID-based filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->